### PR TITLE
fixes #123 - allow removing Credit Payoffs increase/onetime settings lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,10 +11,9 @@ Unreleased Changes
   git requirements (ofxclient and ofxparse) that seem unmaintained or inactive, so we can install via ``pip``.
 * `Issue #115 <https://github.com/jantman/biweeklybudget/issues/115>`_ - In Transactions view, add ability to filter by budget.
 * Change ``BiweeklyPayPeriod`` class to never convert to floats (always use decimal.Decimal types).
-* **Experimental** - `Issue #117 <https://github.com/jantman/biweeklybudget/issues/117>`_ - Experimental, initial support for pushbutton balancing of budgets in the most recent previous payperiod.
-  This feature will transfer funds between periodic budgets in the pay period attempting to get them all to a zero remaining amount. Once as many periodic budgets are zeroed as possible, a user-selected
-  standing budget will be used to transfer excess funds to or cover negative budgets from. Finally, funds will be transferred to or from the standing budget to result in the overall remaining amount for
-  the pay period being zero. This feature is new and experimental, and the confirmation dialog should be closely checked for accuracy and correctness.
+* **Experimental** - `Issue #117 <https://github.com/jantman/biweeklybudget/issues/117>`_ - Experimental, initial support for pushbutton balancing of budgets in the most recent previous payperiod. This feature will transfer funds between periodic budgets in the pay period attempting to get them all to a zero remaining amount. Once as many periodic budgets are zeroed as possible, a user-selected standing budget will be used to transfer excess funds to or cover negative budgets from. Finally, funds will be transferred to or from the standing budget to result in the overall remaining amount for the pay period being zero. This feature is new and experimental, and the confirmation dialog should be closely checked for accuracy and correctness.
+* `Issue #124 <https://github.com/jantman/biweeklybudget/issues/124>`_ - Major changes to the ``ofxgetter`` and ``ofxbackfiller`` console scripts; centralize all database access in them to the new ``biweeklybudget.ofxapi.local.OfxApiLocal`` class and allow these scripts to function remotely, interacting with the ReST API instead of requiring direct database access.
+* `Issue #123 <https://github.com/jantman/biweeklybudget/issues/123>`_ - Modify the Credit Payoffs view to allow removal of Increase and Onetime Payment settings lines.
 
 0.4.0 (2017-08-22)
 ------------------

--- a/biweeklybudget/flaskapp/static/js/credit_payoffs.js
+++ b/biweeklybudget/flaskapp/static/js/credit_payoffs.js
@@ -54,7 +54,7 @@ function addIncrease(settings) {
   s = s + '<label for="payoff_increase_frm_' + idx + '_amt" class="control-label sr-only">Payment Increase ' + idx + ' Amount</label>';
   s = s + '<div class="input-group">';
   s = s + '<span class="input-group-addon">$</span><input class="form-control" id="payoff_increase_frm_' + idx + '_amt" name="payoff_increase_frm_' + idx + '_amt" type="text" size="8" style="width: auto;" onchange="setChanged()">';
-  s = s + '</div> .</div></form>';
+  s = s + '</div> . (<a href="#" onclick="removeIncrease(' + idx + ')" id="rm_increase_' + idx + '_link">remove</a>)</div></form>';
   s = s + '<!-- /#payoff_increase_frm_' + idx + ' -->';
   $('#payoff_increase_forms').append(s);
   if ( settings !== undefined ) {
@@ -68,6 +68,13 @@ function addIncrease(settings) {
     todayHighlight: true,
     format: 'yyyy-mm-dd'
   });
+}
+
+/**
+ * Remove the specified Increase form.
+ */
+function removeIncrease(idx) {
+  $('#payoff_increase_frm_' + idx).remove();
 }
 
 /**
@@ -98,7 +105,7 @@ function addOnetime(settings) {
   s = s + '<label for="payoff_onetime_frm_' + idx + '_amt" class="control-label sr-only">Onetime Payment ' + idx + ' Amount</label>';
   s = s + '<div class="input-group">';
   s = s + '<span class="input-group-addon">$</span><input class="form-control" id="payoff_onetime_frm_' + idx + '_amt" name="payoff_onetime_frm_' + idx + '_amt" type="text" size="8" style="width: auto;" onchange="setChanged()">';
-  s = s + '</div> to the payment amount.</div></form>';
+  s = s + '</div> to the payment amount. (<a href="#" onclick="removeOnetime(' + idx + ')" id="rm_onetime_' + idx + '_link">remove</a>)</div></form>';
   s = s + '<!-- /#payoff_onetime_frm_' + idx + ' -->';
   $('#payoff_onetime_forms').append(s);
   if ( settings !== undefined ) {
@@ -112,6 +119,13 @@ function addOnetime(settings) {
     todayHighlight: true,
     format: 'yyyy-mm-dd'
   });
+}
+
+/**
+ * Remove the specified Onetime form.
+ */
+function removeOnetime(idx) {
+  $('#payoff_onetime_frm_' + idx).remove();
 }
 
 /**

--- a/biweeklybudget/tests/acceptance/flaskapp/views/test_credit_payoffs.py
+++ b/biweeklybudget/tests/acceptance/flaskapp/views/test_credit_payoffs.py
@@ -442,3 +442,30 @@ class TestSettings(AcceptanceHelper):
             ],
             ['Totals', '13.5 years', '$9,627.86', '$3,177.15']
         ]
+
+    def test_10_input_and_save_remove_lines(self, base_url, selenium):
+        self.get(selenium, base_url + '/accounts/credit-payoff')
+        selenium.find_element_by_id('rm_increase_2_link').click()
+        selenium.find_element_by_id('rm_onetime_1_link').click()
+        selenium.find_element_by_id('btn_recalc_payoffs').click()
+        assert len(selenium.find_elements_by_class_name('formfeedback')) == 0
+
+    def test_11_verify_db(self, testdb):
+        b = testdb.query(DBSetting).get('credit-payoff')
+        assert b is not None
+        assert b.value == json.dumps({
+            'increases': [
+                {
+                    'enabled': True,
+                    'date': '2017-05-14',
+                    'amount': '160.23'
+                }
+            ],
+            'onetimes': [
+                {
+                    'enabled': False,
+                    'date': '2017-07-21',
+                    'amount': '98.76'
+                }
+            ]
+        }, sort_keys=True)


### PR DESCRIPTION
Allows removing the setting lines on the Credit Payoffs view