### PR TITLE
Acceptance tests use chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache:
 services:
   - mysql
 
+addons:
+  apt:
+    packages:
+      - google-chrome-stable
+
 before_install:
   - mysql -u root -h 127.0.0.1 -e 'CREATE DATABASE budgettest;'
   - mysql -u root -h 127.0.0.1 -e 'CREATE DATABASE budgettest27;'
@@ -46,6 +51,12 @@ install:
 - pip install tox codecov boto3
 - pip freeze
 - virtualenv --version
+- wget -N http://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip -P ~/
+- unzip ~/chromedriver_linux64.zip -d ~/
+- rm ~/chromedriver_linux64.zip
+- chmod +x ~/chromedriver
+- cp ~/chromedriver ~/bin/
+
 script:
   - tox -r
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 
-cache:
-  directories:
-    - $HOME/.pip-cache/
+cache: pip
 
 services:
   - mysql
@@ -28,21 +26,21 @@ env:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py27 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=py27
     - python: "3.3"
-      env: TOXENV=py33 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=py33
     - python: "3.4"
-      env: TOXENV=py34 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=py34
     - python: "3.5"
-      env: TOXENV=py35 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=py35
     - python: "3.6"
-      env: TOXENV=py36 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=py36
     - python: "2.7"
-      env: TOXENV=acceptance27 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache DB_CONNSTRING='mysql+pymysql://root@127.0.0.1:3306/budgettest27?charset=utf8mb4'
+      env: TOXENV=acceptance27 DB_CONNSTRING='mysql+pymysql://root@127.0.0.1:3306/budgettest27?charset=utf8mb4'
     - python: "3.6"
-      env: TOXENV=acceptance36 PIP_DOWNLOAD_CACHE=$HOME/.pip-cache DB_CONNSTRING='mysql+pymysql://root@127.0.0.1:3306/budgettest36?charset=utf8mb4'
+      env: TOXENV=acceptance36 DB_CONNSTRING='mysql+pymysql://root@127.0.0.1:3306/budgettest36?charset=utf8mb4'
     - python: "3.6"
-      env: TOXENV=docs PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+      env: TOXENV=docs
 
 install:
 - virtualenv --version

--- a/biweeklybudget/tests/conftest.py
+++ b/biweeklybudget/tests/conftest.py
@@ -204,6 +204,12 @@ def selenium(selenium):
     return selenium
 
 
+@pytest.fixture
+def chrome_options(chrome_options):
+    chrome_options.add_argument('headless')
+    return chrome_options
+
+
 """
 Begin generated/parametrized tests for interest calculation.
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -77,7 +77,7 @@ There's a pytest marker for integration tests, effectively defined as anything t
 Acceptance Tests
 ++++++++++++++++
 
-There are acceptance tests, which use a real MySQL DB (see the connection string in ``tox.ini`` and ``conftest.py``) and a real Flask HTTP server, and selenium. Run them via the ``acceptance`` tox environment.
+There are acceptance tests, which use a real MySQL DB (see the connection string in ``tox.ini`` and ``conftest.py``) and a real Flask HTTP server, and selenium. Run them via the ``acceptance`` tox environment. Note that they're currently configured to use Headless Chrome; running them locally will require a modern Chrome version that supports the ``--headless`` flag (Chrome 59+) and a matching version of `chromedriver <https://sites.google.com/a/chromium.org/chromedriver/>`_.
 
 The acceptance tests connect to a local MySQL database using a connection string specified by the ``DB_CONNSTRING`` environment variable, or defaulting to a DB name and user/password that can be seen in ``conftest.py``. Once connected, the tests will drop all tables in the test DB, re-create all models/tables, and then load sample data. After the DB is initialized, tests will run the local Flask app on a random port, and run Selenium backed by PhantomJS.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-dateutil==2.6.0
 python-editor==1.0.3
 pytz
 requests==2.13.0
-selenium==3.0.2
+selenium==3.6.0
 six==1.10.0
 versionfinder==0.1.0
 # dependencies of biweeklybudget/vendored/wishlist

--- a/tox.ini
+++ b/tox.ini
@@ -168,7 +168,7 @@ commands =
     virtualenv --version
     pip --version
     pip freeze
-    py.test -rxs -vv --durations=10 --driver PhantomJS --html=results/acceptance.html -m "acceptance" biweeklybudget
+    py.test -rxs -vv --durations=10 --driver Chrome --html=results/acceptance.html -m "acceptance" biweeklybudget
 
 [testenv:acceptance36]
 deps = {[testenv:acceptance27]deps}


### PR DESCRIPTION
Switch acceptance tests from using PhantomJS to Chrome. PhantomJS is problematic and also lacks modern javascript features, namely the ``Intl`` support that we'll need for #140. Now that Chrome has a built-in headless mode, we can run it both locally and in the Docker-based TravisCI tests.

This build works for me locally (on Arch Linux) using Chrome Stable 62.0.3202.62 and chromedriver 2.33.506092, and is currently working in TravisCI.