### PR TITLE
Issues/139 - option to omit budgets from spending graphs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased Changes
   * Reminder to sign git release tags
   * Add ``dev/release.py`` script to handle GitHub releases.
 
+* `Issue #139 <https://github.com/jantman/biweeklybudget/issues/139>`_ - Add field to Budget model to allow omitting specific budgets from spending graphs (the graphs on the Budgets view).
+
 0.5.0 (2017-10-28)
 ------------------
 

--- a/biweeklybudget/alembic/versions/6d37400ea9cd_add_omit_from_graphs_boolean_to_budget_.py
+++ b/biweeklybudget/alembic/versions/6d37400ea9cd_add_omit_from_graphs_boolean_to_budget_.py
@@ -1,0 +1,28 @@
+"""add omit_from_graphs boolean to Budget model
+
+Revision ID: 6d37400ea9cd
+Revises: 61e62ef50513
+Create Date: 2017-11-11 07:45:36.580049
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6d37400ea9cd'
+down_revision = '61e62ef50513'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'budgets',
+        sa.Column('omit_from_graphs', sa.Boolean(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('budgets', 'omit_from_graphs')

--- a/biweeklybudget/flaskapp/static/js/budgets_modal.js
+++ b/biweeklybudget/flaskapp/static/js/budgets_modal.js
@@ -68,6 +68,7 @@ function budgetModalDivForm() {
         .addCurrency('budget_frm_current_balance', 'current_balance', 'Current Balance', { groupHtml: 'style="display: none;"' })
         .addCheckbox('budget_frm_active', 'is_active', 'Active?', true)
         .addCheckbox('budget_frm_income', 'is_income', 'Income?')
+        .addCheckbox('budget_frm_omit_from_graphs', 'omit_from_graphs', 'Omit from graphs?')
         .render();
 }
 
@@ -99,6 +100,11 @@ function budgetModalDivFillAndShow(msg) {
         $('#budget_frm_income').prop('checked', true);
     } else {
         $('#budget_frm_income').prop('checked', false);
+    }
+    if(msg['omit_from_graphs'] === true) {
+        $('#budget_frm_omit_from_graphs').prop('checked', true);
+    } else {
+        $('#budget_frm_omit_from_graphs').prop('checked', false);
     }
     $("#modalDiv").modal('show');
 }

--- a/biweeklybudget/flaskapp/views/budgets.py
+++ b/biweeklybudget/flaskapp/views/budgets.py
@@ -197,6 +197,10 @@ class BudgetFormHandler(FormHandlerView):
             budget.is_income = True
         else:
             budget.is_income = False
+        if data['omit_from_graphs'] == 'true':
+            budget.omit_from_graphs = True
+        else:
+            budget.omit_from_graphs = False
         logger.info('%s: %s', action, budget.as_dict)
         db_session.add(budget)
         db_session.commit()
@@ -365,7 +369,8 @@ class BudgetSpendingChartView(MethodView):
     def _budget_names(self):
         return {
             x.id: x.name for x in db_session.query(Budget).filter(
-                Budget.is_income.__eq__(False)
+                Budget.is_income.__eq__(False),
+                Budget.omit_from_graphs.__eq__(False)
             ).all()
         }
 

--- a/biweeklybudget/models/budget_model.py
+++ b/biweeklybudget/models/budget_model.py
@@ -71,6 +71,9 @@ class Budget(Base, ModelAsDict):
     #: whether this is an Income budget (True) or expense (False).
     is_income = Column(Boolean, default=False)
 
+    #: whether or not to omit this budget from spending graphs
+    omit_from_graphs = Column(Boolean, default=False)
+
     def __repr__(self):
         return "<Budget(id=%d)>" % (
             self.id

--- a/biweeklybudget/tests/acceptance/flaskapp/views/test_budgets.py
+++ b/biweeklybudget/tests/acceptance/flaskapp/views/test_budgets.py
@@ -113,6 +113,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert b.starting_balance == 100.00
         assert b.is_active is True
         assert b.is_income is False
+        assert b.omit_from_graphs is False
 
     def test_01_budget_modal_populate_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -140,6 +141,8 @@ class TestBudgetModals(AcceptanceHelper):
         assert selenium.find_element_by_id('budget_frm_active').is_selected()
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_02_budget_modal_update_modal(self, base_url, selenium):
         # Fill in the form
@@ -163,6 +166,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected() is False
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
         # submit the form
         selenium.find_element_by_id('modalSaveButton').click()
         self.wait_for_jquery_done(selenium)
@@ -191,6 +196,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert float(b.starting_balance) == 2345.6700
         assert b.is_active is False
         assert b.is_income is False
+        assert b.omit_from_graphs is False
 
     def test_10_populate_edit_periodic_2_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -218,6 +224,8 @@ class TestBudgetModals(AcceptanceHelper):
         assert selenium.find_element_by_id('budget_frm_active').is_selected()
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_11_populate_edit_periodic_3_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -248,6 +256,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected() is False
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_12_populate_edit_standing_1_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -275,6 +285,8 @@ class TestBudgetModals(AcceptanceHelper):
         assert selenium.find_element_by_id('budget_frm_active').is_selected()
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is True
 
     def test_13_populate_edit_standing_2_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -302,6 +314,8 @@ class TestBudgetModals(AcceptanceHelper):
         assert selenium.find_element_by_id('budget_frm_active').is_selected()
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_14_populate_edit_standing_3_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -332,6 +346,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected() is False
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_20_income_verify_db(self, testdb):
         b = testdb.query(Budget).get(7)
@@ -342,6 +358,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert float(b.starting_balance) == 2345.67
         assert b.is_active is True
         assert b.is_income is True
+        assert b.omit_from_graphs is True
 
     def test_21_populate_income_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets')
@@ -368,6 +385,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_current_balance_group').is_displayed() is False
         assert selenium.find_element_by_id('budget_frm_active').is_selected()
         assert selenium.find_element_by_id('budget_frm_income').is_selected()
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is True
 
     def test_22_update_income_modal(self, base_url, selenium):
         # Fill in the form
@@ -390,6 +409,9 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected() is False
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is True
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is True
+        selenium.find_element_by_id('budget_frm_omit_from_graphs').click()
         # submit the form
         selenium.find_element_by_id('modalSaveButton').click()
         self.wait_for_jquery_done(selenium)
@@ -419,6 +441,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert float(b.starting_balance) == 123.45
         assert b.is_active is False
         assert b.is_income is True
+        assert b.omit_from_graphs is False
 
     def test_31_populate_direct_url_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/budgets/1')
@@ -445,6 +468,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected() is False
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
 
     def test_41_add_standing_modal(self, base_url, selenium):
         # Fill in the form
@@ -469,6 +494,8 @@ class TestBudgetModals(AcceptanceHelper):
             'budget_frm_active').is_selected()
         assert selenium.find_element_by_id(
             'budget_frm_income').is_selected() is False
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
         # submit the form
         selenium.find_element_by_id('modalSaveButton').click()
         self.wait_for_jquery_done(selenium)
@@ -497,6 +524,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert float(b.current_balance) == 6789.12
         assert b.is_active is True
         assert b.is_income is False
+        assert b.omit_from_graphs is False
 
     def test_51_add_income_modal(self, base_url, selenium):
         # Fill in the form
@@ -522,6 +550,9 @@ class TestBudgetModals(AcceptanceHelper):
         income = selenium.find_element_by_id('budget_frm_income')
         income.click()
         assert income.is_selected()
+        assert selenium.find_element_by_id(
+            'budget_frm_omit_from_graphs').is_selected() is False
+        selenium.find_element_by_id('budget_frm_omit_from_graphs').click()
         # submit the form
         selenium.find_element_by_id('modalSaveButton').click()
         self.wait_for_jquery_done(selenium)
@@ -551,6 +582,7 @@ class TestBudgetModals(AcceptanceHelper):
         assert float(b.starting_balance) == 123.45
         assert b.is_active is True
         assert b.is_income is True
+        assert b.omit_from_graphs is True
 
 
 @pytest.mark.acceptance

--- a/biweeklybudget/tests/fixtures/sampledata.py
+++ b/biweeklybudget/tests/fixtures/sampledata.py
@@ -121,7 +121,8 @@ class SampleDataLoader(object):
                 name='Standing1',
                 is_periodic=False,
                 description='S1desc',
-                current_balance=1284.23
+                current_balance=1284.23,
+                omit_from_graphs=True
             ),
             'Standing2': Budget(
                 name='Standing2',
@@ -141,7 +142,8 @@ class SampleDataLoader(object):
                 is_periodic=True,
                 description='IncomeDesc',
                 starting_balance=2345.67,
-                is_income=True
+                is_income=True,
+                omit_from_graphs=True
             )
         }
         for x in [


### PR DESCRIPTION
Fixes #139 - add field and modal option to omit budgets from spending graphs