### PR TITLE
fixes #157 - remove PhantomJS from docker image, as it's broken

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 Unreleased Changes
 ------------------
 
-* `Issue #170 <https://github.com/jantman/biweeklybudget/issues/170>`_ Upgrade **all** python dependencies to their latest versions.
-* `Issue #171 <https://github.com/jantman/biweeklybudget/issues/171>`_ Upgrade Docker base image from ``python:3.6.3-alpine3.4`` to ``python:3.6.4-alpine3.7``.
+* `Issue #170 <https://github.com/jantman/biweeklybudget/issues/170>`_ - Upgrade **all** python dependencies to their latest versions.
+* `Issue #171 <https://github.com/jantman/biweeklybudget/issues/171>`_ - Upgrade Docker base image from ``python:3.6.3-alpine3.4`` to ``python:3.6.4-alpine3.7``.
+* `Issue #157 <https://github.com/jantman/biweeklybudget/issues/157>`_ - Remove PhantomJS from Docker image, as it's broken and shouldn't be needed.
 
 0.7.0 (2018-01-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Vault (if you choose to take advantage of the OFX downloading), which you can al
 * To use the automated OFX transaction downloading functionality:
 
   * A running, reachable instance of `Hashicorp Vault <https://www.vaultproject.io/>`_ with your financial institution web credentials stored in it.
-  * `PhantomJS <http://phantomjs.org/>`_ for downloading transaction data from institutions that do not support OFX remote access ("Direct Connect").
+  * If your bank does not support OFX remote access ("Direct Connect"), you will need to write a custom screen-scraper class using Selenium and a browser.
 
 Installation
 ------------

--- a/biweeklybudget/tests/docker_build.py
+++ b/biweeklybudget/tests/docker_build.py
@@ -69,7 +69,6 @@ import docker
 from io import BytesIO
 import tarfile
 from biweeklybudget.version import VERSION
-from textwrap import dedent
 import subprocess
 
 FORMAT = "[%(asctime)s %(levelname)s] %(message)s"

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -79,7 +79,7 @@ Acceptance Tests
 
 There are acceptance tests, which use a real MySQL DB (see the connection string in ``tox.ini`` and ``conftest.py``) and a real Flask HTTP server, and selenium. Run them via the ``acceptance`` tox environment. Note that they're currently configured to use Headless Chrome; running them locally will require a modern Chrome version that supports the ``--headless`` flag (Chrome 59+) and a matching version of `chromedriver <https://sites.google.com/a/chromium.org/chromedriver/>`_.
 
-The acceptance tests connect to a local MySQL database using a connection string specified by the ``DB_CONNSTRING`` environment variable, or defaulting to a DB name and user/password that can be seen in ``conftest.py``. Once connected, the tests will drop all tables in the test DB, re-create all models/tables, and then load sample data. After the DB is initialized, tests will run the local Flask app on a random port, and run Selenium backed by PhantomJS.
+The acceptance tests connect to a local MySQL database using a connection string specified by the ``DB_CONNSTRING`` environment variable, or defaulting to a DB name and user/password that can be seen in ``conftest.py``. Once connected, the tests will drop all tables in the test DB, re-create all models/tables, and then load sample data. After the DB is initialized, tests will run the local Flask app on a random port, and run Selenium backed by headless Chrome.
 
 If you want to run the acceptance tests without dumping and refreshing the test database, export the ``NO_REFRESH_DB`` environment variable. Setting the ``NO_CLASS_REFRESH_DB``
 environment variable will prevent refreshing the DB after classes that manipulate data;

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -18,7 +18,7 @@ Vault (the latter only if you choose to take advantage of the OFX downloading), 
 * To use the automated OFX transaction downloading functionality:
 
   * A running, reachable instance of `Hashicorp Vault <https://www.vaultproject.io/>`_ with your financial institution web credentials stored in it.
-  * `PhantomJS <http://phantomjs.org/>`_ for downloading transaction data from institutions that do not support OFX remote access ("Direct Connect").
+  * If your bank does not support OFX remote access ("Direct Connect"), you will need to write a custom screen-scraper class using Selenium and a browser.
 
 Installation
 ------------

--- a/docs/source/ofx.rst
+++ b/docs/source/ofx.rst
@@ -126,8 +126,6 @@ OFX statements should be saved. After instantiating the class, ``ofxgetter`` wil
 call the class's ``run()`` method with no arguments, and expect to receive an OFX
 statement string back.
 
-If cookies are a concern, be aware that saving and loading cookies is
-`broken in PhantomJS 2.x <https://github.com/ariya/phantomjs/issues/13115>`_.
 If you need to persist cookies across sessions, look into the
 :py:class:`~biweeklybudget.screenscraper.ScreenScraper` class'
 :py:meth:`~biweeklybudget.screenscraper.ScreenScraper.load_cookies` and
@@ -187,7 +185,7 @@ Here's a simple, contrived example of such a class:
             super(MyScraper, self).__init__(
                 savedir=savedir, screenshot=screenshot
             )
-            self.browser = self.get_browser('phantomjs')
+            self.browser = self.get_browser('chrome-headless')
             self.username = username
             self.password = password
             self.acct_num = acct_num


### PR DESCRIPTION
Fixes #157

The PhantomJS package in the Docker image is broken. The only thing it was being used for was custom [screenscraper](http://biweeklybudget.readthedocs.io/en/latest/biweeklybudget.screenscraper.html)-based OFX retrieval, which can now be accomplished on another system using ofxgetter's remote mode.