### PR TITLE
issue #105 - capture LiveServer logs during acceptance tests

### DIFF
--- a/biweeklybudget/flaskapp/app.py
+++ b/biweeklybudget/flaskapp/app.py
@@ -36,6 +36,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 import logging
+import os
 
 from flask import Flask
 
@@ -47,6 +48,13 @@ format = "%(asctime)s [%(levelname)s %(filename)s:%(lineno)s - " \
          "%(name)s.%(funcName)s() ] %(message)s"
 logging.basicConfig(level=logging.DEBUG, format=format)
 logger = logging.getLogger()
+
+if 'BIWEEKLYBUDGET_LOG_FILE' in os.environ:
+    # mainly for acceptance tests
+    fhandler = logging.FileHandler(os.environ['BIWEEKLYBUDGET_LOG_FILE'])
+    fhandler.setLevel(logging.DEBUG)
+    fhandler.setFormatter(logging.Formatter(fmt=format))
+    logger.addHandler(fhandler)
 
 fix_werkzeug_logger()
 


### PR DESCRIPTION
During the work for #105 I was seeing some modal input failures that were failing validation with a pretty generic attribute error, but no further info. I really needed the testflask LiveServer logs to debug it, but they're not being captured since LiveServer runs under multiprocessing.

This took me quite a while to figure out. There are some comments [here](https://github.com/jantman/biweeklybudget/issues/105#issuecomment-367519778) and [here](https://github.com/jantman/biweeklybudget/issues/105#issuecomment-367537021) about it.

This PR is the culmination of a few hours of research. I'm sure there's a better way to do this, but it didn't seem like the canonical ways (i.e. QueueHandler and QueueListener) would work under pytest.

This should at least work for now.