### PR TITLE
plaid_update updates, docs, misc CI fixes

### DIFF
--- a/.github/workflows/run-tox-suite.yml
+++ b/.github/workflows/run-tox-suite.yml
@@ -238,6 +238,12 @@ jobs:
         run: python -m pip install --upgrade pip && pip install tox pymysql
       - name: Setup test DB
         run: python dev/setup_test_db.py
+      - name: Login to Docker Hub if master branch
+        if: github.ref_type == "branch" && github.ref_name == "master"
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Run tests
         run: tox -e ${{ github.job }}
       - name: Archive code coverage results
@@ -250,6 +256,10 @@ jobs:
             results/
             coverage.xml
             htmlcov/
+      - name: Docker Push if master
+        if: github.ref_type == "branch" && github.ref_name == "master"
+        run: |
+          docker push jantman/biweeklybudget:${{ steps.docker-build.outputs.DOCKER_IMG_TAG }}
   migrations:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/run-tox-suite.yml
+++ b/.github/workflows/run-tox-suite.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Setup test DB
         run: python dev/setup_test_db.py
       - name: Login to Docker Hub if master branch
-        if: github.ref_type == "branch" && github.ref_name == "master"
+        if: github.ref_type == 'branch' && github.ref_name == 'master'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -257,7 +257,7 @@ jobs:
             coverage.xml
             htmlcov/
       - name: Docker Push if master
-        if: github.ref_type == "branch" && github.ref_name == "master"
+        if: github.ref_type == 'branch' && github.ref_name == 'master'
         run: |
           docker push jantman/biweeklybudget:${{ steps.docker-build.outputs.DOCKER_IMG_TAG }}
   migrations:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.1.1 (2022-12-30)
+------------------
+
+* Docker build - don't include ``-dirty`` in version/tag when building in GHA
+* Document how to change Plaid environments
+* Bug Fix (1.1.0) - Plaid Link javascript broken by undefined variable ``BIWEEKLYBUDGET_VERSION``
+
 1.1.0 (2022-12-29)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,11 @@
 Changelog
 =========
 
-1.1.1 (2022-12-30)
+Unreleased Changes
 ------------------
 
 * Docker build - don't include ``-dirty`` in version/tag when building in GHA
 * Document how to change Plaid environments
-* Bug Fix (1.1.0) - Plaid Link javascript broken by undefined variable ``BIWEEKLYBUDGET_VERSION``
 
 1.1.0 (2022-12-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased Changes
 * Docker build - don't include ``-dirty`` in version/tag when building in GHA
 * Document how to change Plaid environments
 * GHA - Push built Docker images to Docker Hub, for builds of master branch
+* Document triggering a Plaid update via the ``/plaid-update`` endpoint.
+* Change ``/plaid-update`` endpoint argument name from ``account_ids`` to ``item_ids``.
+* Add ``num_days`` parameter support to ``/plaid-update`` endpoint.
 
 1.1.0 (2022-12-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased Changes
 
 * Docker build - don't include ``-dirty`` in version/tag when building in GHA
 * Document how to change Plaid environments
+* GHA - Push built Docker images to Docker Hub, for builds of master branch
 
 1.1.0 (2022-12-29)
 ------------------

--- a/biweeklybudget/flaskapp/views/plaid.py
+++ b/biweeklybudget/flaskapp/views/plaid.py
@@ -240,27 +240,28 @@ class PlaidUpdate(MethodView):
 
     This single endpoint has multiple functions:
 
-    * If called with no query parameters, displays a form template to use to
+    * If GET with no query parameters, displays a form template to use to
       interactively update Plaid accounts.
-    * If called with an ``item_ids`` query argument, performs a Plaid update
-      of the specified CSV list of Plaid Item IDs, or all Plaid-enabled accounts
-      if the value is ``ALL``. The response from this endpoint can be in one of
-      three forms:
+    * If GET or POST with an ``item_ids`` query parameter, performs a Plaid
+      update (via :py:meth:`~._update`) of the specified CSV list of Plaid Item
+      IDs, or all Plaid Items if the value is ``ALL``. The response from this
+      endpoint can be in one of three forms:
 
       * If the ``Accept`` HTTP header is set to ``application/json``, return a
         JSON list of update results. Each list item is the JSON-ified value of
         :py:attr:`~.PlaidUpdateResult.as_dict`.
       * If the ``Accept`` HTTP header is set to ``text/plain``, return a plain
         text human-readable summary of the update operation.
-      * Otherwise, return a templated view of the update operation results.
+      * Otherwise, return a templated view of the update operation results, as
+        would be returned to a browser.
     """
 
     def post(self):
         """
-        Handle POST. If the ``account_ids`` query parameter is set, then return
+        Handle POST. If the ``item_ids`` query parameter is set, then return
         :py:meth:`~._update`, else return a HTTP 400.
         """
-        ids = request.args.get('account_ids')
+        ids = request.args.get('item_ids')
         if ids is None and request.form:
             ids = ','.join([
                 x.replace('item_', '') for x in request.form.keys()
@@ -268,22 +269,31 @@ class PlaidUpdate(MethodView):
         if ids is None:
             return jsonify({
                 'success': False,
-                'message': 'Missing parameter: account_ids'
+                'message': 'Missing parameter: item_ids'
             }), 400
         return self._update(ids)
 
     def get(self):
         """
-        Handle GET. If the ``account_ids`` query parameter is set, then return
+        Handle GET. If the ``item_ids`` query parameter is set, then return
         :py:meth:`~._update`, else return :py:meth:`~._form`.
         """
-        ids = request.args.get('account_ids')
+        ids = request.args.get('item_ids')
         if ids is None:
             return self._form()
         return self._update(ids)
 
     def _update(self, ids):
-        """Handle an update for Plaid accounts."""
+        """
+        Handle an update for Plaid accounts by instantiating a
+        :py:class:`~.PlaidUpdater`, calling its :py:meth:`~.PlaidUpdater.update`
+        method with the proper arguments, and then returning the result in a
+        form determined by the ``Accept`` header.
+
+        :param ids: a comma-separated string listing the :py:class:`~.PlaidItem`
+        IDs to update, or the string ``ALL`` to update all Items.
+        :type ids: str
+        """
         logger.info('Handle Plaid Update request; item_ids=%s', ids)
         updater = PlaidUpdater()
         if ids == 'ALL':

--- a/biweeklybudget/tests/docker_build.py
+++ b/biweeklybudget/tests/docker_build.py
@@ -166,6 +166,8 @@ class DockerImageBuilder(object):
         repo = Repo(path=self._gitdir, search_parent_directories=False)
         res['sha'] = repo.head.commit.hexsha
         res['dirty'] = repo.is_dirty(untracked_files=True)
+        if os.environ.get('GITHUB_ACTIONS') == 'true':
+            res['dirty'] = False
         res['tag'] = None
         for tag in repo.tags:
             # each is a git.Tag object

--- a/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
+++ b/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
@@ -781,6 +781,20 @@ class TestPlaidUpdate:
         assert m_update.mock_calls == [call('id1,id2')]
         assert m_jsonify.mock_calls == []
 
+    def test_post_num_days(self):
+        mock_update = Mock()
+        mock_request = Mock(
+            form=None, args={'item_ids': 'id1,id2', 'num_days': '12'}
+        )
+        with patch(f'{pbm}.request', mock_request):
+            with patch(f'{self.pb}._update') as m_update:
+                with patch(f'{pbm}.jsonify') as m_jsonify:
+                    m_update.return_value = mock_update
+                    res = self.cls.post()
+        assert res == mock_update
+        assert m_update.mock_calls == [call('id1,id2', num_days=12)]
+        assert m_jsonify.mock_calls == []
+
     def test_post_form(self):
         mock_update = Mock()
         mock_request = Mock(
@@ -838,6 +852,20 @@ class TestPlaidUpdate:
         assert res == mock_update
         assert m_form.mock_calls == []
         assert m_update.mock_calls == [call(self.cls, '1,2,3')]
+
+    def test_get_update_num_days(self):
+        mock_req = Mock(args={'item_ids': '1,2,3', 'num_days': '25'})
+        mock_form = Mock()
+        mock_update = Mock()
+        with patch(f'{self.pb}._form', autospec=True) as m_form:
+            m_form.return_value = mock_form
+            with patch(f'{self.pb}._update', autospec=True) as m_update:
+                m_update.return_value = mock_update
+                with patch(f'{pbm}.request', mock_req):
+                    res = self.cls.get()
+        assert res == mock_update
+        assert m_form.mock_calls == []
+        assert m_update.mock_calls == [call(self.cls, '1,2,3', num_days=25)]
 
     def test_form(self):
         accts = [
@@ -951,10 +979,10 @@ class TestPlaidUpdate:
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
             call.available_items(),
-            call().update(items=items)
+            call().update(items=items, days=30)
         ]
         assert mock_updater.mock_calls == [
-            call.update(items=items)
+            call.update(items=items, days=30)
         ]
         assert mocks['render_template'].mock_calls == [call(
             'plaid_result.html',
@@ -1025,10 +1053,10 @@ class TestPlaidUpdate:
         assert res == mock_json
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
-            call().update(items=[items[0]])
+            call().update(items=[items[0]], days=30)
         ]
         assert mock_updater.mock_calls == [
-            call.update(items=[items[0]])
+            call.update(items=[items[0]], days=30)
         ]
         assert mocks['render_template'].mock_calls == []
         assert mocks['jsonify'].mock_calls == [
@@ -1109,10 +1137,92 @@ class TestPlaidUpdate:
                       "TOTAL: 1 updated, 2 added, 1 account(s) failed"
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
-            call().update(items=[items[0]])
+            call().update(items=[items[0]], days=30)
         ]
         assert mock_updater.mock_calls == [
-            call.update(items=[items[0]])
+            call.update(items=[items[0]], days=30)
+        ]
+        assert mocks['render_template'].mock_calls == []
+        assert mocks['jsonify'].mock_calls == []
+        assert mock_db.mock_calls == [
+            call.query(PlaidItem),
+            call.query().get('Item1'),
+        ]
+
+    def test_update_plain_nondefault_num_days(self):
+        mock_req = Mock(headers={'accept': 'text/plain'})
+        accts = [
+            Mock(spec_set=Account, id='AID1'),
+            Mock(spec_set=Account, id='AID2')
+        ]
+        type(accts[0]).name = 'AName1'
+        type(accts[1]).name = 'AName2'
+        plaid_accts = [
+            Mock(spec_set=PlaidAccount, mask='XXX1', account=accts[0]),
+            Mock(spec_set=PlaidAccount, mask='XXX2', account=None),
+            Mock(spec_set=PlaidAccount, mask='XXX3', account=accts[1]),
+        ]
+        type(plaid_accts[0]).name = 'Acct1'
+        type(plaid_accts[1]).name = 'Acct2'
+        type(plaid_accts[2]).name = 'Acct3'
+        items = [
+            Mock(
+                spec_set=PlaidItem, item_id='Item1',
+                all_accounts=[plaid_accts[0], plaid_accts[1]],
+                institution_name='InstName1'
+            ),
+            Mock(
+                spec_set=PlaidItem, item_id='Item2',
+                all_accounts=[plaid_accts[2]],
+                institution_name='InstName2'
+            )
+        ]
+
+        def db_get(_id):
+            if _id == 'Item1':
+                return items[0]
+            if _id == 'Item2':
+                return items[1]
+
+        mock_db = Mock()
+        mock_query = Mock()
+        mock_query.get.side_effect = db_get
+        mock_db.query.return_value = mock_query
+        mock_updater = Mock()
+        rendered = Mock()
+        mock_json = Mock()
+        result = [
+            Mock(
+                success=True, updated=1, added=2, as_dict='res1',
+                stmt_ids='SID1,SID2,SID3', item=items[0]
+            ),
+            Mock(
+                success=False, item=items[1], exc='MyException'
+            )
+        ]
+        mock_updater.update.return_value = result
+        with patch.multiple(
+            pbm,
+            PlaidUpdater=DEFAULT,
+            render_template=DEFAULT,
+            jsonify=DEFAULT
+        ) as mocks:
+            mocks['PlaidUpdater'].return_value = mock_updater
+            mocks['PlaidUpdater'].available_accounts.return_value = items
+            mocks['render_template'].return_value = rendered
+            mocks['jsonify'].return_value = mock_json
+            with patch(f'{pbm}.request', mock_req):
+                with patch(f'{pbm}.db_session', mock_db):
+                    res = self.cls._update('Item1', num_days=12)
+        assert res == "InstName1 (Item1): 1 updated, 2 added (stmts: SID1," \
+                      "SID2,SID3)\nInstName2 (Item2): Failed: MyException\n" \
+                      "TOTAL: 1 updated, 2 added, 1 account(s) failed"
+        assert mocks['PlaidUpdater'].mock_calls == [
+            call(),
+            call().update(items=[items[0]], days=12)
+        ]
+        assert mock_updater.mock_calls == [
+            call.update(items=[items[0]], days=12)
         ]
         assert mocks['render_template'].mock_calls == []
         assert mocks['jsonify'].mock_calls == []

--- a/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
+++ b/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
@@ -771,7 +771,7 @@ class TestPlaidUpdate:
 
     def test_post(self):
         mock_update = Mock()
-        mock_request = Mock(form=None, args={'account_ids': 'id1,id2'})
+        mock_request = Mock(form=None, args={'item_ids': 'id1,id2'})
         with patch(f'{pbm}.request', mock_request):
             with patch(f'{self.pb}._update') as m_update:
                 with patch(f'{pbm}.jsonify') as m_jsonify:
@@ -807,7 +807,7 @@ class TestPlaidUpdate:
         assert m_update.mock_calls == []
         assert m_jsonify.mock_calls == [
             call({
-                'success': False, 'message': 'Missing parameter: account_ids'
+                'success': False, 'message': 'Missing parameter: item_ids'
             })
         ]
 
@@ -826,7 +826,7 @@ class TestPlaidUpdate:
         assert m_update.mock_calls == []
 
     def test_get_update(self):
-        mock_req = Mock(args={'account_ids': '1,2,3'})
+        mock_req = Mock(args={'item_ids': '1,2,3'})
         mock_form = Mock()
         mock_update = Mock()
         with patch(f'{self.pb}._form', autospec=True) as m_form:

--- a/biweeklybudget/version.py
+++ b/biweeklybudget/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 PROJECT_URL = 'https://github.com/jantman/biweeklybudget'

--- a/docs/source/plaid.rst
+++ b/docs/source/plaid.rst
@@ -45,4 +45,14 @@ TBD.
 Troubleshooting
 ---------------
 
-API responses from Plaid are logged at debug-level. The UI process of linking an account via Plaid happens mostly in client-side JavaScript, which logs pertinent information to the browser's console log. The Plaid Dashboard (accessed by logging in to plaid.com) also provides some useful debug information.
+API responses from Plaid are logged at debug-level. The UI process of linking an account via Plaid happens mostly in client-side JavaScript, which logs pertinent information to the browser's console log. The `Plaid Dashboard <https://dashboard.plaid.com/>`__ also provides some useful debug information, espeically when correlated with the ``link_token`` and/or ``item_id`` that should be logged by biweeklybudget.
+
+Changing Plaid Environments
+---------------------------
+
+It may be necessary to change Plaid environments, such as if you started using the Development environment and then switched to Production for OAuth2 integrations. This process is relatively manual and will not affect transactions, but will require setting up Plaid again.
+
+1. Un-associate all of your Accounts from Plaid Accounts. This can be done manually via the Account edit modal or by running the following SQL query directly against the database: ``UPDATE accounts SET plaid_item_id=NULL, plaid_account_id=NULL;``
+2. Delete all of your Plaid Accounts and Plaid Items from the database: ``DELETE FROM plaid_accounts; DELETE FROM plaid_items;``
+3. Update your configuration / environment variables for the new ``PLAID_ENV`` that you want to use and your ``PLAID_SECRET`` for that environment.
+4. Re-link all of your Plaid items, and then re-associate them with your Accounts.

--- a/docs/source/plaid.rst
+++ b/docs/source/plaid.rst
@@ -11,6 +11,8 @@ The Plaid component uses the same "OFX" models in biweeklybudget that the older 
 
 **IMPORTANT** As of late 2022, a handful of financial institutions, Chase being the most notable, require `OAuth2 integration via Plaid <https://plaid.com/docs/link/oauth/>`__. This requires that your Plaid account request and be approved for Production environment access, which is a non-trivial process that requires additional legal agreements and a security and privacy review. In addition, Chase has their own partner review process that includes a security review. While it is *possible* for an individual to pass these reviews for a personal project, it's far from trivial. I would only recommend this for folks who have professional experience developing and operating applications that handle financial data, and who intend to operate biweeklybudget in a similar fashion.
 
+.. _plaid.configuration:
+
 Configuration
 -------------
 
@@ -24,28 +26,73 @@ biweeklybudget needs to be configured with your Plaid credentials. I highly reco
 * ``PLAID_PRODUCTS`` - The Plaid products you are requesting access to. Right now, for biweeklybudget, this should be ``transactions``.
 * ``PLAID_COUNTRY_CODES`` - A comma-separated list of country codes that you want to be able to select institutions from. Only ``US`` has been tested.
 
+.. _plaid.usage:
+
 Usage
 -----
+
+.. _plaid.linking:
 
 Linking Accounts to Plaid
 +++++++++++++++++++++++++
 
-To link an account via Plaid, open the Account modal (by clicking on any link to the account, such as those on the ``/accounts`` view) and scroll down to the bottom.
+**TBD**
+
+.. _plaid.update-ui:
 
 Updating Transactions via UI
 ++++++++++++++++++++++++++++
 
-TBD.
+Updating through the UI will retrieve transactions for the last 30 days. If you want to retrieve more than that, you must do so :ref:`via the API <plaid.update-api>`.
+
+1. Click the "Plaid Update" link in the left navigation menu.
+2. In the "Plaid Update Transactions" table, select the Plaid Items that you want to update transactions for.
+3. Click the "Update Transactions" button at the bottom of the table.
+4. When the update is complete, you will be redirected to a page showing results in a table.
+
+.. _plaid.update-api:
 
 Updating Transactions via API
 +++++++++++++++++++++++++++++
 
-TBD.
+Transactions can be updated via a simple API at the same ``/plaid-update`` endpoint. This API can return either a JSON or human-readable plain-text output depending on the ``Accept`` header. For full documentation, see the documentation of :py:class:`~.PlaidUpdate` and :py:meth:`~.PlaidUpdate.post`.
+
+In short, the endpoint takes a POST or GET request that specifies an ``item_ids`` parameter as a string comma-separated list of :py:class:`~.PlaidItem` IDs to update, or the special string ``ALL`` to update all Items. Optionally, you can specify a ``num_days`` parameter to retrieve transactions for something other than the last 30 days. The response is either JSON if the ``Accept`` header is set to ``application/json`` or human-readable plain text if set to ``text/plain`` (if set to any other value, it will return the full HTML that would be sent to the browser).
+
+The following examples assume that biweeklybudget is available at ``http://127.0.0.1:8080``
+
+To update transactions for all Plaid Items via a GET request and return human-readable text:
+
+.. code-block:: bash
+
+    curl -H 'Accept: text/plain' 'http://127.0.0.1:8080/plaid-update?account_ids=ALL'
+
+      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                     Dload  Upload   Total   Spent    Left  Speed
+
+      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+      0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
+      0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
+      0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
+    100   874  100   874    0     0    231      0  0:00:03  0:00:03 --:--:--   232
+    AcctOne (plaidItemId1): 23 updated, 0 added (stmts: [21728])
+    AcctTwo (plaidItemId2): 31 updated, 0 added (stmts: [21729])
+    AcctThree (plaidItemId3): 35 updated, 3 added (stmts: [21730])
+    TOTAL: 89 updated, 3 added, 0 account(s) failed
+
+To update transactions for Plaid Items with IDs plaidItemId1 and plaidItemId2 for the last 60 days via a POST, and return JSON:
+
+**TBD**
+
+.. _plaid.troubleshooting:
 
 Troubleshooting
 ---------------
 
 API responses from Plaid are logged at debug-level. The UI process of linking an account via Plaid happens mostly in client-side JavaScript, which logs pertinent information to the browser's console log. The `Plaid Dashboard <https://dashboard.plaid.com/>`__ also provides some useful debug information, espeically when correlated with the ``link_token`` and/or ``item_id`` that should be logged by biweeklybudget.
+
+.. _plaid.change-env:
 
 Changing Plaid Environments
 ---------------------------

--- a/docs/source/plaid.rst
+++ b/docs/source/plaid.rst
@@ -50,7 +50,9 @@ API responses from Plaid are logged at debug-level. The UI process of linking an
 Changing Plaid Environments
 ---------------------------
 
-It may be necessary to change Plaid environments, such as if you started using the Development environment and then switched to Production for OAuth2 integrations. This process is relatively manual and will not affect transactions, but will require setting up Plaid again.
+It may be necessary to change Plaid environments, such as if you started using the Development environment and then switched to Production for OAuth2 integrations. This process will require setting up Plaid again.
+
+Also **note** that Plaid ``transaction_id`` (our ``fitid``) _will_ change between environments. As such, you should update transactions in the old environment immediately before switching environments, then update transactions in the new environment, and you will need to manually ignore any transactions that are duplicates.
 
 1. Un-associate all of your Accounts from Plaid Accounts. This can be done manually via the Account edit modal or by running the following SQL query directly against the database: ``UPDATE accounts SET plaid_item_id=NULL, plaid_account_id=NULL;``
 2. Delete all of your Plaid Accounts and Plaid Items from the database: ``DELETE FROM plaid_accounts; DELETE FROM plaid_items;``


### PR DESCRIPTION
* Docker build - don't include ``-dirty`` in version/tag when building in GHA
* Document how to change Plaid environments
* GHA - Push built Docker images to Docker Hub, for builds of master branch
* Document triggering a Plaid update via the ``/plaid-update`` endpoint.
* Change ``/plaid-update`` endpoint argument name from ``account_ids`` to ``item_ids``.
* Add ``num_days`` parameter support to ``/plaid-update`` endpoint.