### PR TITLE
Fix Tox test suite (#325)

### DIFF
--- a/.github/workflows/run-tox-suite.yml
+++ b/.github/workflows/run-tox-suite.yml
@@ -28,9 +28,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         run: tox -e ${{ github.job }}
       - name: Archive test results and artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ always() }}
         with:
           name: test-results-and-coverage-${{ github.job }}
@@ -56,9 +56,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -70,13 +70,13 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
-        run: python -m pip install --upgrade pip && pip install tox && npm install -g jsdoc
+        run: python -m pip install --upgrade pip && pip install tox && npm install -g jsdoc@4.0.4
       - name: Run tests
         run: tox -e ${{ github.job }}
   screenshots:
@@ -101,9 +101,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -134,9 +134,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -148,7 +148,7 @@ jobs:
       - name: Run tests
         run: tox -e ${{ github.job }}
       - name: Archive test results and artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ always() }}
         with:
           name: test-results-and-coverage-${{ github.job }}
@@ -186,9 +186,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -200,7 +200,7 @@ jobs:
       - name: Run tests
         run: tox -e ${{ github.job }}
       - name: Archive test results and artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ always() }}
         with:
           name: test-results-and-coverage-${{ github.job }}
@@ -230,9 +230,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -251,7 +251,7 @@ jobs:
         id: run-tests
         run: tox -e ${{ github.job }}
       - name: Archive test results and artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ always() }}
         with:
           name: test-results-and-coverage-${{ github.job }}
@@ -286,9 +286,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbroot
           MYSQL_ROOT_HOST: '%'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install dependencies
@@ -300,7 +300,7 @@ jobs:
       - name: Run tests
         run: tox -e ${{ github.job }}
       - name: Archive test results and artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: ${{ always() }}
         with:
           name: test-results-and-coverage-${{ github.job }}
@@ -317,9 +317,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: test-results-and-coverage-py314
       - name: Extract coverage percentage
@@ -355,7 +355,7 @@ jobs:
           echo "" >> coverage_comment.md
           echo "🔍 **Generated by**: Unit tests (\`tox -e py314\`)" >> coverage_comment.md
       - name: Comment PR with coverage
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+1.6.1 (2026-09-06)
+------------------
+
+* `Issue #325 <https://github.com/jantman/biweeklybudget/issues/325>`_ - Fix the tox test suite so that all environments pass locally and in CI.
+
+  * ``docs`` environment: the ``linkcheck`` build was failing because Stack Overflow now returns HTTP 403 to automated requests; add ``stackoverflow.com`` to ``linkcheck_ignore`` in ``docs/source/conf.py``.
+  * Update all documentation links that had moved or now redirect: Docker ``docker run`` reference, Flask server docs, tox docs (``tox.wiki``), chromedriver docs, Alembic docs, the startbootstrap-sb-admin-2 repository, the BCP 47 spec (``rfc-editor.org``), and ``http://`` links to sites that now redirect to ``https://``.
+  * Add ``linkcheck_timeout`` and ``linkcheck_retries`` to ``docs/source/conf.py`` so that a transient network error no longer fails the whole docs build.
+  * Fix Sphinx deprecation warnings: set ``language = 'en'`` instead of ``None``, drop the deprecated ``sphinx_rtd_theme.get_html_theme_path()`` call, and point the intersphinx SQLAlchemy/selenium inventories at ``https://`` URLs.
+  * Pin the ``jsdoc`` version installed in CI to 4.0.4 and document that jsdoc 4.x is required (jsdoc 3.x crashes on Node.js 22+).
+  * Update the GitHub Actions used by the workflow off of the deprecated Node 20 runtime.
+  * ``plaid`` environment: wrap the raw SQL statements in ``test_plaidlink.py`` in ``sqlalchemy.text()``; SQLAlchemy 2.0 rejects bare textual SQL passed to ``Session.execute()``. This failure was masked in CI because the whole test class is marked ``xfail`` when ``CI=true``.
+  * ``docker`` environment: allow ``docker_build.py`` to run from a Git worktree, where ``.git`` is a file pointing at the real Git directory rather than a directory itself.
+
 1.6.0 (2026-02-14)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,15 +9,15 @@ biweeklybudget
    :target: https://readthedocs.org/projects/biweeklybudget/?badge=latest
    :alt: sphinx documentation for latest release
 
-.. image:: http://www.repostatus.org/badges/latest/active.svg
+.. image:: https://www.repostatus.org/badges/latest/active.svg
    :alt: Project Status: Active – The project has reached a stable, usable state and is being actively developed.
-   :target: http://www.repostatus.org/#active
+   :target: https://www.repostatus.org/#active
 
 Responsive Flask/SQLAlchemy personal finance app, specifically for biweekly budgeting.
 
-**For full documentation**, see `http://biweeklybudget.readthedocs.io/en/latest/ <http://biweeklybudget.readthedocs.io/en/latest/>`_
+**For full documentation**, see `https://biweeklybudget.readthedocs.io/en/latest/ <https://biweeklybudget.readthedocs.io/en/latest/>`_
 
-**For screenshots**, see `<http://biweeklybudget.readthedocs.io/en/latest/screenshots.html>`_
+**For screenshots**, see `<https://biweeklybudget.readthedocs.io/en/latest/screenshots.html>`_
 
 Overview
 --------
@@ -44,7 +44,7 @@ application is **not** designed to be accessible in any way to anyone other than
 over the web, someone *will* get your account numbers, or worse).
 
 *Note:* Any potential users outside of the US should see the documentation section on
-`Currency Formatting and Localization <http://biweeklybudget.readthedocs.io/en/latest/app_usage.html#currency-formatting-and-localization>`_;
+`Currency Formatting and Localization <https://biweeklybudget.readthedocs.io/en/latest/app_usage.html#currency-formatting-and-localization>`_;
 the short version is that I've done my best to make this configurable, but as far as I know I'm the
 only person using this software. If anyone else wants to use it and it doesn't work for your currency
 or locale, let me know and I'll fix it.
@@ -69,13 +69,13 @@ Main Features
 Requirements
 ------------
 
-**Note:** Alternatively, biweeklybudget is also distributed as a `Docker container <http://biweeklybudget.readthedocs.io/en/latest/flask_app.html>`_.
+**Note:** Alternatively, biweeklybudget is also distributed as a `Docker container <https://biweeklybudget.readthedocs.io/en/latest/flask_app.html>`_.
 Using the dockerized version will eliminate all of these dependencies aside from MySQL (which you can run in another container) and
 Vault (if you choose to take advantage of the OFX downloading), which you can also run in another container.
 
 * Python 3.7+ (currently tested and developed with 3.14).
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
-* MySQL, or a compatible database (e.g. `MariaDB <https://mariadb.org/>`_). biweeklybudget uses `SQLAlchemy <http://www.sqlalchemy.org/>`_ for database abstraction, but currently specifies some MySQL-specific options, and is only tested with MySQL.
+* MySQL, or a compatible database (e.g. `MariaDB <https://mariadb.org/>`_). biweeklybudget uses `SQLAlchemy <https://www.sqlalchemy.org/>`_ for database abstraction, but currently specifies some MySQL-specific options, and is only tested with MySQL.
 * To use the automated Plaid transaction downloading functionality, a valid `Plaid <https://plaid.com/>`__ account.
 * To use the automated OFX Direct Connect transaction downloading functionality:
 

--- a/biweeklybudget/db_event_handlers.py
+++ b/biweeklybudget/db_event_handlers.py
@@ -273,7 +273,7 @@ def query_profile_before(conn, cursor, statement, parameters, context, _):  # no
     Engine's ``before_cursor_execute`` event.
 
     For information, see:
-    http://docs.sqlalchemy.org/en/latest/faq/performance.html#query-profiling
+    https://docs.sqlalchemy.org/en/latest/faq/performance.html#query-profiling
     """
     conn.info.setdefault('query_start_time', []).append(time.time())
     logger.debug(
@@ -288,7 +288,7 @@ def query_profile_after(conn, cursor, statement, parameters, context, _):  # noq
     Engine's ``after_cursor_execute`` event.
 
     For information, see:
-    http://docs.sqlalchemy.org/en/latest/faq/performance.html#query-profiling
+    https://docs.sqlalchemy.org/en/latest/faq/performance.html#query-profiling
     """
     total = time.time() - conn.info['query_start_time'].pop(-1)
     logger.debug(
@@ -301,7 +301,7 @@ def init_event_listeners(db_session, engine):
     """
     Initialize/register all SQLAlchemy event listeners.
 
-    See http://docs.sqlalchemy.org/en/latest/orm/events.html
+    See https://docs.sqlalchemy.org/en/latest/orm/events.html
 
     :param db_session: the Database Session
     :type db_session: sqlalchemy.orm.scoping.scoped_session

--- a/biweeklybudget/flaskapp/templates/help.html
+++ b/biweeklybudget/flaskapp/templates/help.html
@@ -7,7 +7,7 @@
                 <div class="col-lg-12">
                     <ul>
                         <li><strong>Project Homepage:</strong> <a href="{{ url }}">{{ url }}</a></li>
-                        <li><strong>Documentation:</strong> <a href="http://biweeklybudget.readthedocs.io/">http://biweeklybudget.readthedocs.io/</a> <em>(for this version: <a href="http://biweeklybudget.readthedocs.io/en/{{ version }}/">http://biweeklybudget.readthedocs.io/en/{{ version }}/</a>)</em></li>
+                        <li><strong>Documentation:</strong> <a href="https://biweeklybudget.readthedocs.io/">https://biweeklybudget.readthedocs.io/</a> <em>(for this version: <a href="https://biweeklybudget.readthedocs.io/en/{{ version }}/">https://biweeklybudget.readthedocs.io/en/{{ version }}/</a>)</em></li>
                         <li><strong>Issues / Bug Reports / Support:</strong> <a href="https://github.com/jantman/biweeklybudget/issues">https://github.com/jantman/biweeklybudget/issues</a></li>
                         <li><strong>Code Repository:</strong> <a href="https://github.com/jantman/biweeklybudget">https://github.com/jantman/biweeklybudget</a></li>
                     </ul>

--- a/biweeklybudget/models/transaction.py
+++ b/biweeklybudget/models/transaction.py
@@ -171,7 +171,7 @@ class Transaction(Base, ModelAsDict):
 
     @actual_amount.expression
     def actual_amount(cls):
-        # see: http://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html
+        # see: https://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html
         # #correlated-subquery-relationship-hybrid
         return select(
             func.sum(BudgetTransaction.amount)

--- a/biweeklybudget/settings.py
+++ b/biweeklybudget/settings.py
@@ -83,7 +83,7 @@ _STRING_VARS = [
     'PLAID_USER_ID',
 ]
 
-#: A `RFC 5646 / BCP 47 <https://tools.ietf.org/html/bcp47>`_ Language Tag
+#: A `RFC 5646 / BCP 47 <https://www.rfc-editor.org/info/bcp47>`_ Language Tag
 #: with a Region suffix to use for number (currency) formatting, i.e. "en_US",
 #: "en_GB", "de_DE", etc. If this is not specified (None), it will be looked up
 #: from environment variables in the following order: LC_ALL, LC_MONETARY, LANG.
@@ -275,7 +275,7 @@ try:
 except UnknownLocaleError:
     raise SystemExit(
         'ERROR: LOCALE_NAME setting of "%s" is not a valid BCP 47 Language Tag.'
-        ' See <https://tools.ietf.org/html/bcp47> for more information.' %
+        ' See <https://www.rfc-editor.org/info/bcp47> for more information.' %
         LOCALE_NAME
     )
 

--- a/biweeklybudget/tests/acceptance/test_plaidlink.py
+++ b/biweeklybudget/tests/acceptance/test_plaidlink.py
@@ -42,6 +42,8 @@ import pytest
 import time
 import re
 
+from sqlalchemy import text
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -91,7 +93,7 @@ class TestLinkAndUpdateSimple(AcceptanceHelper):
             'DELETE FROM budget_transactions;',
             'DELETE FROM transactions;',
         ]:
-            testdb.execute(stmt)
+            testdb.execute(text(stmt))
         testdb.flush()
         testdb.commit()
         self.plaid_accts = {}

--- a/biweeklybudget/tests/docker_build.py
+++ b/biweeklybudget/tests/docker_build.py
@@ -147,9 +147,11 @@ class DockerImageBuilder(object):
             'Initializing DockerImageBuilder; toxinidir=%s gitdir=%s',
             self._toxinidir, self._gitdir
         )
-        if not os.path.exists(self._gitdir) or not os.path.isdir(self._gitdir):
+        # Note: in a git worktree (or a submodule) ``.git`` is a file containing
+        # a pointer to the real git directory, rather than a directory itself.
+        if not os.path.exists(self._gitdir):
             raise RuntimeError(
-                'Error: %s does not exist or is not a directory' % self._gitdir
+                'Error: %s does not exist' % self._gitdir
             )
         logger.debug('Connecting to Docker')
         self._docker = docker.from_env()
@@ -164,7 +166,7 @@ class DockerImageBuilder(object):
         """
         res = {}
         logger.debug('Checking git status...')
-        repo = Repo(path=self._gitdir, search_parent_directories=False)
+        repo = Repo(path=self._toxinidir, search_parent_directories=False)
         res['sha'] = repo.head.commit.hexsha
         res['dirty'] = repo.is_dirty(untracked_files=True)
         if os.environ.get('GITHUB_ACTIONS') == 'true':

--- a/biweeklybudget/vendored/README.rst
+++ b/biweeklybudget/vendored/README.rst
@@ -7,7 +7,7 @@ aren't responding to pull requests, or packages that haven't uploaded a recent
 release to PyPI).
 
 For information on updating these packages, see the
-`Development - Vendored Requirements <http://biweeklybudget.readthedocs.io/en/latest/development.html#vendored-requirements>`_
+`Development - Vendored Requirements <https://biweeklybudget.readthedocs.io/en/latest/development.html#vendored-requirements>`_
 section of the documentation.
 
 For the licenses that each of these dependencies are distributed under, see

--- a/biweeklybudget/version.py
+++ b/biweeklybudget/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 PROJECT_URL = 'https://github.com/jantman/biweeklybudget'

--- a/docs/source/app_usage.rst
+++ b/docs/source/app_usage.rst
@@ -14,7 +14,7 @@ Currency Formatting and Localization
 biweeklybudget supports configurable currency symbols and display/formatting,
 controlled by the :py:attr:`~biweeklybudget.settings.LOCALE_NAME` and
 :py:attr:`~biweeklybudget.settings.CURRENCY_CODE` settings. The former must
-specify a `RFC 5646 / BCP 47 <https://tools.ietf.org/html/bcp47>`_ language tag
+specify a `RFC 5646 / BCP 47 <https://www.rfc-editor.org/info/bcp47>`_ language tag
 with a region identifier (i.e. "en_US", "en_GB", "de_DE", etc.). If it is not
 set in the settings module or via a ``LOCALE_NAME`` environment variable, it
 will be looked up from the ``LC_ALL``, ``LC_MONETARY``, or ``LANG`` environment

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -133,11 +133,9 @@ todo_include_todos = True
 # -- Options for HTML output ----------------------------------------------
 
 if is_rtd:
-    import sphinx_rtd_theme
+    # sphinx_rtd_theme >= 1.0 registers itself as a Sphinx extension and
+    # supplies its own theme path; setting html_theme_path here is deprecated.
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [
-        sphinx_rtd_theme.get_html_theme_path(),
-    ]
     html_static_path = ['_static']
     htmlhelp_basename = 'budgetdoc'
 
@@ -298,9 +296,9 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sqlalchemy': (
-        'http://docs.sqlalchemy.org/en/13/', None
+        'https://docs.sqlalchemy.org/en/20/', None
     ),
-    'selenium': ('http://selenium-python.readthedocs.io/', None)
+    'selenium': ('https://selenium-python.readthedocs.io/', None)
 }
 
 autoclass_content = 'class'
@@ -323,7 +321,13 @@ linkcheck_ignore = [
     r'https?://.*\.flaticon\.com/.*',  # Flaticon blocks automated requests
     r'https?://www\.gnu\.org/.*',  # Sometimes unreachable
     r'https?://developer\.hashicorp\.com/.*',  # Rate-limits automated requests
+    r'https?://(www\.)?stackoverflow\.com/.*',  # Blocks automated requests (403)
 ]
+
+# Some sites are slow and/or intermittently unreachable from CI; retry rather
+# than failing the whole docs build on a transient network error.
+linkcheck_timeout = 20
+linkcheck_retries = 3
 
 nitpick_ignore = [
     ('py:class', 'flask.views.MethodView'),

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -88,7 +88,7 @@ database often.
 Testing
 -------
 
-Testing is done via `pytest <https://docs.pytest.org/en/latest/>`_, driven by `tox <https://tox.readthedocs.io/>`_.
+Testing is done via `pytest <https://docs.pytest.org/en/latest/>`_, driven by `tox <https://tox.wiki/en/latest/>`_.
 
 * testing is as simple as:
 
@@ -118,7 +118,7 @@ There's a pytest marker for integration tests, effectively defined as anything t
 Acceptance Tests
 ++++++++++++++++
 
-There are acceptance tests, which use a real MySQL DB (see the connection string in ``tox.ini`` and ``conftest.py``) and a real Flask HTTP server, and selenium. Run them via the ``acceptance`` tox environment. Note that they're currently configured to use Headless Chrome; running them locally will require a modern Chrome version that supports the ``--headless`` flag (Chrome 59+) and a matching version of `chromedriver <https://sites.google.com/a/chromium.org/chromedriver/>`_.
+There are acceptance tests, which use a real MySQL DB (see the connection string in ``tox.ini`` and ``conftest.py``) and a real Flask HTTP server, and selenium. Run them via the ``acceptance`` tox environment. Note that they're currently configured to use Headless Chrome; running them locally will require a modern Chrome version that supports the ``--headless`` flag (Chrome 59+) and a matching version of `chromedriver <https://developer.chrome.com/docs/chromedriver/>`_.
 
 The acceptance tests connect to a local MySQL database using a connection string specified by the ``DB_CONNSTRING`` environment variable, or defaulting to a DB name and user/password that can be seen in ``conftest.py``. Once connected, the tests will drop all tables in the test DB, re-create all models/tables, and then load sample data. After the DB is initialized, tests will run the local Flask app on a random port, and run Selenium backed by headless Chrome.
 
@@ -158,7 +158,7 @@ This tox environment is configured via environment variables. Please note that i
 Alembic DB Migrations
 ---------------------
 
-This project uses `Alembic <http://alembic.zzzcomputing.com/en/latest/index.html>`_
+This project uses `Alembic <https://alembic.sqlalchemy.org/en/latest/index.html>`_
 for DB migrations.
 
 .. important::
@@ -245,12 +245,17 @@ Use the ``docker`` tox environment. See the docstring at the top of
 Frontend / UI
 -------------
 
-The UI is based on `BlackrockDigital's startbootstrap-sb-admin-2 <https://github.com/BlackrockDigital/startbootstrap-sb-admin-2>`_,
+The UI is based on `StartBootstrap's startbootstrap-sb-admin-2 <https://github.com/StartBootstrap/startbootstrap-sb-admin-2>`_,
 currently as of the 3.3.7-1 GitHub release. It is currently not modified at all, but should it need to be rebuilt,
 this can be done with: ``pushd biweeklybudget/flaskapp/static/startbootstrap-sb-admin-2 && gulp``
 
 Sphinx also generates documentation for the custom javascript files. This must be done manually
 on a machine with `jsdoc <https://jsdoc.app/>`_ installed, via: ``tox -e jsdoc``.
+
+``jsdoc`` 4.x is required; jsdoc 3.x (still packaged by some distributions) crashes
+on Node.js 22 and newer, and ``tox -e jsdoc`` then fails with ``jsdoc found no JS
+files``. CI pins the version installed; to match it locally, install jsdoc with
+``npm install -g jsdoc@4.0.4``.
 
 .. _development.vendored_requirements:
 

--- a/docs/source/flask_app.rst
+++ b/docs/source/flask_app.rst
@@ -9,7 +9,7 @@ Running Flask Development Server
 Flask comes bundled with a builtin development server for fast local development and testing.
 This is an easy way to take biweeklybudget for a spin, but carries some important and critical
 warnings if you use it with real data. For upstream documentation, see the
-`Flask Development Server docs <https://flask.palletsprojects.com/en/1.1.x/server/>`_. Please note that
+`Flask Development Server docs <https://flask.palletsprojects.com/en/stable/server/>`_. Please note that
 the development server is a single process and defaults to single-threaded, and is only realistically
 usable by one user.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -14,7 +14,7 @@ Vault (the latter only if you choose to take advantage of the OFX downloading), 
 
 * Python 3.10+ (currently developed and tested with 3.14).
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
-* MySQL, or a compatible database (e.g. `MariaDB <https://mariadb.org/>`_ ). biweeklybudget uses `SQLAlchemy <http://www.sqlalchemy.org/>`_ for database abstraction, but currently specifies some MySQL-specific options, and is only tested with MySQL.
+* MySQL, or a compatible database (e.g. `MariaDB <https://mariadb.org/>`_ ). biweeklybudget uses `SQLAlchemy <https://www.sqlalchemy.org/>`_ for database abstraction, but currently specifies some MySQL-specific options, and is only tested with MySQL.
 * To use the new :ref:`Plaid <plaid>` automated transaction downloading functionality, a valid Plaid account.
 * To use the (old) automated OFX transaction downloading functionality:
 
@@ -144,7 +144,7 @@ The only dependencies for a Docker installation are:
 is backed up and will not be removed.
 
 The `image <https://hub.docker.com/r/jantman/biweeklybudget/>`_ runs with the `tini <https://github.com/krallin/tini>`_ init
-wrapper and uses `gunicorn <http://gunicorn.org/>`_ under Python 3.14 to serve the web UI, exposed on port 80. Note that,
+wrapper and uses `gunicorn <https://gunicorn.org/>`_ under Python 3.14 to serve the web UI, exposed on port 80. Note that,
 while it runs with 4 worker threads, there is no HTTP proxy in front of Gunicorn and this image is intended for local network
 use by a single user/client. The image also automatically runs database migrations in a safe manner at start, before starting
 the Flask application.
@@ -202,7 +202,7 @@ you'll need to know the host system's IP address (as seen from the container). O
 using the default "bridge" Docker networking mode, this will coorespond to the container's
 gateway (the gateway of the Docker network that the container is in) and will usually be
 ``172.x.0.1``. Using the special ``host-gateway`` option available in the
-`docker run command --add-host option <https://docs.docker.com/engine/reference/commandline/run/#add-host>`_,
+`docker run command --add-host option <https://docs.docker.com/reference/cli/docker/container/run/#add-host>`_,
 we can add ``--add-host=host.docker.internal:host-gateway`` to our ``docker run`` command and
 then use that as the hostname in the DB connection string:
 
@@ -229,14 +229,14 @@ You may need to adjust those commands depending on your operating system, Docker
 MySQL Connection Errors
 +++++++++++++++++++++++
 
-On resource-constrained systems or with MySQL servers tuned for minimal resource utilization, you may see the Flask application returning HTTP 500 errors after periods of inactivity, with the Flask application log reporting something like "Lost connection to MySQL server during query" and MySQL reporting "Aborted connection" errors. This is due to connections in the SQLAlchemy connection pool timing out, but the application not being aware of that. If this happens, you can set the ``SQL_POOL_PRE_PING`` environment variable (to any value). This will enable SQLAlchemy's ``pool_pre_ping`` feature (see `Disconnect Handling - Pessimistic <http://docs.sqlalchemy.org/en/latest/core/pooling.html#pool-disconnects-pessimistic>`_) which tests that connections are still working before executing queries with them.
+On resource-constrained systems or with MySQL servers tuned for minimal resource utilization, you may see the Flask application returning HTTP 500 errors after periods of inactivity, with the Flask application log reporting something like "Lost connection to MySQL server during query" and MySQL reporting "Aborted connection" errors. This is due to connections in the SQLAlchemy connection pool timing out, but the application not being aware of that. If this happens, you can set the ``SQL_POOL_PRE_PING`` environment variable (to any value). This will enable SQLAlchemy's ``pool_pre_ping`` feature (see `Disconnect Handling - Pessimistic <https://docs.sqlalchemy.org/en/latest/core/pooling.html#pool-disconnects-pessimistic>`_) which tests that connections are still working before executing queries with them.
 
 Settings Module Example
 +++++++++++++++++++++++
 
 If you need to provide biweeklybudget with more complicated configuration, this is
 still possible via a Python settings module. The easiest way to inject one into the
-Docker image is to `mount <https://docs.docker.com/engine/reference/commandline/run/#read-only>`_
+Docker image is to `mount <https://docs.docker.com/reference/cli/docker/container/run/#read-only>`_
 a python module directly into the biweeklybudget package directory. Assuming you have
 a custom settings module on your local machine at ``/opt/biweeklybudget-settings.py``, you would
 run the container as shown below to mount the custom settings module into the container and use it.

--- a/docs/source/jsdoc.projects.rst
+++ b/docs/source/jsdoc.projects.rst
@@ -12,3 +12,18 @@ File: ``biweeklybudget/flaskapp/static/js/projects.js``
 .. js:function:: .................d()
 
    Handler for when a project is added via the form.
+.. js:function:: ...........l(id)
+
+   Show the Project edit modal popup, populated with information for one
+   Project. This function calls projectModalDivForm to generate the form HTML,
+   projectModalDivFillAndShow to populate the form for editing, and handleForm
+   to handle the Submit action.
+
+   :param id: the ID of the Project to show a modal for.
+   :type id: **number**
+.. js:function:: .........................w(msg)
+
+   Ajax callback to fill in the modal with data on a Project.
+.. js:function:: ..................m()
+
+   Generate the HTML for the project edit modal form.

--- a/docs/source/ofx.rst
+++ b/docs/source/ofx.rst
@@ -16,7 +16,7 @@ using HTTP only, via the `ofxclient <https://github.com/captin411/ofxclient>`_ p
 (note we vendor-in a fork with some bug fixes). For banks that do not support the
 OFX protocol and require you to use their website to download OFX format statements,
 biweeklybudget provides a base :py:class:`~biweeklybudget.screenscraper.ScreenScraper`
-class that can be used to develop a `selenium <http://selenium-python.readthedocs.io/>`_-based
+class that can be used to develop a `selenium <https://selenium-python.readthedocs.io/>`_-based
 tool to automate logging in to your bank's site and downloading the OFX file.
 
 In order to use either of these methods, you must have an instance of `Hashicorp Vault <https://developer.hashicorp.com/vault>`_
@@ -36,7 +36,7 @@ implications of this program as well as Vault, and to understand the risks of st
 your banking credentials in this way.
 
 Also note that biweeklybudget includes a base class (:py:class:`~biweeklybudget.screenscraper.ScreenScraper`)
-intended to simplify developing `selenium <http://selenium-python.readthedocs.io/>`_-based
+intended to simplify developing `selenium <https://selenium-python.readthedocs.io/>`_-based
 browser automation to log in to financial institution websites and download your transactions.
 Many banks and other financial institutions have terms of service that
 *explicitly forbid automated or programmatic use of their websites*. As such, it is up to you


### PR DESCRIPTION
Fixes #325.

## What was actually broken

Only one tox environment fails in CI today: `docs`. Every other job on the last `master` run (`py314`, `jsdoc`, `screenshots`, `acceptance`, `plaid`, `docker`, `migrations`) is green.

The `docs` failure is `sphinx-build -b linkcheck`. Stack Overflow now answers automated requests with **HTTP 403**, and four files link to Stack Overflow answers:

```
(biweeklybudget.screenscraper: line 4)        broken  http://stackoverflow.com/a/15791319       - 403 Client Error
(biweeklybudget.flaskapp.cli_commands: line 3) broken  http://stackoverflow.com/a/41666467/211734 - 403 Client Error
(biweeklybudget.utils: line 4)                broken  http://stackoverflow.com/a/5891598/211734  - 403 Client Error
(jsdoc.forms: line 76)                        broken  http://stackoverflow.com/a/7356528/211734  - 403 Client Error
```

Running the suite locally turned up three more problems that CI does not surface. Those are fixed here too.

## Changes

### `docs`

- Add `stackoverflow.com` to `linkcheck_ignore`, alongside the sites already listed there for the same reason (Wikipedia, NIST NVD, Flaticon, HashiCorp).
- Add `linkcheck_timeout = 20` / `linkcheck_retries = 3` so one flaky network call no longer fails the whole docs build.
- Update every link that had moved or now redirects — the issue names this as a recurring cause:
  - `docs.docker.com/engine/reference/commandline/run/` → `docs.docker.com/reference/cli/docker/container/run/`
  - `flask.palletsprojects.com/en/1.1.x/server/` → `.../en/stable/server/`
  - `tox.readthedocs.io` → `tox.wiki/en/latest/`
  - `sites.google.com/a/chromium.org/chromedriver/` → `developer.chrome.com/docs/chromedriver/` (the old URL now redirects to a Google login page)
  - `alembic.zzzcomputing.com` → `alembic.sqlalchemy.org`
  - `github.com/BlackrockDigital/startbootstrap-sb-admin-2` → `github.com/StartBootstrap/...`
  - `tools.ietf.org/html/bcp47` → `www.rfc-editor.org/info/bcp47`
  - `http://` → `https://` for readthedocs.io, repostatus.org, sqlalchemy.org, gunicorn.org, selenium-python.readthedocs.io, docs.sqlalchemy.org
- Clear the two Sphinx deprecation warnings: `language = 'en'` instead of `None`, and drop the deprecated `sphinx_rtd_theme.get_html_theme_path()` call. Point the intersphinx SQLAlchemy inventory at the 2.0 docs over https (the project runs SQLAlchemy 2.0.45; it was pinned to the 1.3 docs).

Historical `CHANGES.rst` links were left alone; they only redirect, which is not fatal.

### `jsdoc`

CI ran `npm install -g jsdoc` with no version pin. jsdoc 3.x — still packaged by several distributions — crashes on Node.js 22+ because `util.isRegExp` was removed, and `tox -e jsdoc` then fails with the misleading `jsdoc found no JS files in the directories [...]`. Pinned to `jsdoc@4.0.4` in CI and documented the requirement in `docs/source/development.rst`.

Also committing the regenerated `docs/source/jsdoc.projects.rst`, which was missing three functions.

### `plaid`

`test_00_clean_transactions_and_setup` passes bare SQL strings to `Session.execute()`, which SQLAlchemy 2.0 rejects:

```
sqlalchemy.exc.ArgumentError: Textual SQL expression 'UPDATE accounts SET plaid...'
should be explicitly declared as text('UPDATE accounts SET plaid...')
```

Wrapped in `sqlalchemy.text()`. This is invisible in CI because the whole class carries `@pytest.mark.xfail(os.environ.get('CI') == 'true', ...)` for the headless-Chrome Plaid Link issue, so every test in it xfails there regardless of why it failed.

### `docker`

`docker_build.py` required `.git` to be a directory, so `tox -e docker` could not run from a Git worktree, where `.git` is a file pointing at the real Git directory. It now accepts either, and hands the working tree rather than the git dir to GitPython.

### CI workflow

Moved off the actions still targeting the deprecated Node 20 runtime (`checkout@v4`→`v5`, `setup-python@v5`→`v6`, `upload-artifact@v4`→`v5`, `download-artifact@v4`→`v5`, `github-script@v7`→`v8`; the `coverage` job was also still on `checkout@v3`).

## Verification

Run locally against a `mariadb:10.4.7` container, Python 3.14, Chrome 152:

| env | result |
|---|---|
| `py314` | ✅ 388 passed, 127 skipped |
| `docs` | ✅ (was failing) |
| `jsdoc` | ✅ (with jsdoc 4.0.4) |
| `screenshots` | ✅ |
| `acceptance` | ✅ 513 passed, 24 skipped |
| `migrations` | ✅ |
| `docker` | ✅ image built, script + acceptance tests against the container passed |
| `plaid` | ⚠️ see below |

`plaid` now gets past the SQLAlchemy failure (`test_00`–`test_02` pass) and stops at `/ajax/plaid/create_link_token`, which needs real Plaid sandbox credentials. That environment is credential-gated by design — `CLAUDE.md` documents it as "requires Plaid credentials" — so it cannot pass on a machine without them. In CI it has the credentials, and the class is `xfail`ed there anyway.

Regenerated documentation screenshots were deliberately **not** committed: `tox -e screenshots` rewrites all 40-odd PNGs with whatever Chrome rendered them, which is churn unrelated to this fix. Per the release checklist those get regenerated and committed at release time.

## Note on scope

Beyond `jsdoc`, I did not pin the other currently-unpinned dependencies (`cryptography`, `packaging`, `pytz`, `requests` in `requirements.txt`, and the test tooling in `tox.ini`). None of them are implicated in a current failure, Dependabot already tracks `requirements.txt`, and freezing them would trade a real class of breakage for a manual-bump burden. Happy to do it in a follow-up if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Hq5wviNscvifAzrwAxqip