### PR TITLE
Issue #323 - Currency Value Input Normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+1.7.0 (2026-09-06)
+------------------
+
+* `Issue #323 <https://github.com/jantman/biweeklybudget/issues/323>`_ - Normalize currency values entered in the UI, so that all currency inputs accept common formatting.
+
+  * Entering a currency value containing thousands separators, such as ``1,234.56``, previously produced a 500 Internal Server Error. ``FormHandlerView.post()`` wrapped ``submit()`` in a ``try``/``except`` but called ``validate()`` unguarded, and ``TransactionFormHandler.validate()`` calls ``Decimal(data['amount'])`` directly, so ``decimal.InvalidOperation`` propagated out to Flask. Six other validators had the same shape with unguarded ``float()``.
+  * Bare integers were rejected by several inputs; ``123`` had to be entered as ``123.0``. ``FormHandlerView._validate_float()`` asserted ``data[key].startswith('%s' % float(data[key]))``, and ``'123'.startswith('123.0')`` is ``False``.
+  * Add :py:func:`biweeklybudget.utils.parse_currency` and ``CurrencyParseError``, the single server-side authority for interpreting a user-entered amount, alongside the existing ``fmt_currency()``. It wraps ``babel.numbers.parse_decimal(..., strict=True)`` and returns an exact ``Decimal``. Babel was already a dependency; nothing new is added.
+  * Add a matching ``parse_currency()`` to ``biweeklybudget/flaskapp/static/js/custom.js``, alongside its ``fmt_currency()`` counterpart, and use it in place of ``parseFloat()`` in ``transactions_modal.js``. ``parseFloat('1,234.56')`` is ``1``, so budget split validation previously disabled the Save button for any separator-formatted amount, making the fix unreachable in that flow.
+  * Normalize in one place on the server: ``FormHandlerView`` gains ``currency_fields`` and ``decimal_fields`` class attributes and a ``normalize_currency()`` hook that runs before ``validate()``. Every form handler declares its own fields, so all existing ``Decimal()``/``float()`` conversions in ``validate()`` and ``submit()`` are left untouched, and the complete set of currency fields can be found by grepping for those attributes.
+  * Also wrap the ``validate()`` call in ``FormHandlerView.post()`` in a ``try``/``except``, so that no conversion anywhere can produce a 500 again.
+  * All of the following are now accepted (for a ``en_US``/``USD`` configuration): bare integers, comma or space thousands separators (including Unicode spaces), a leading or trailing currency symbol or ISO code, a leading ``+`` or ``-``, parentheses denoting a negative, and surrounding whitespace.
+  * Ambiguously grouped values such as ``10,00``, ``1,23,4.56``, ``1,234,`` and ``,123`` are rejected with a field-level validation error rather than being silently read as ``1000``, ``1234.56``, ``1234`` and ``123``. For an application that tracks real money, guessing at a typo is worse than refusing it.
+  * Locale conventions are read from ``LOCALE_NAME`` and ``CURRENCY_CODE`` on both the server and the client, so adding another locale is a configuration change; this is covered by tests against ``de_DE``.
+  * Reword the validation messages ``Invalid float value: "..."`` and ``Invalid Decimal value: "..."``, which leaked Python type names, to ``Invalid number: "..."`` and ``Invalid amount: "..."``.
+  * Fuel Log ``gallons`` and ``reported_mpg`` are not currency, but shared the validation helper responsible for the bare-integer defect; they are fixed too.
+  * Add unit tests covering the accept/reject matrix and the normalization hook, and Selenium browser tests covering the Transaction modal (including budget splits) plus every other currency input in the application.
+  * Document the accepted input formats in ``docs/source/app_usage.rst``.
+
 1.6.2 (2026-09-06)
 ------------------
 

--- a/biweeklybudget/flaskapp/static/js/custom.js
+++ b/biweeklybudget/flaskapp/static/js/custom.js
@@ -67,6 +67,124 @@ function fmt_currency(value) {
 }
 
 /**
+ * Return the digit grouping separator and decimal separator for
+ * ``LOCALE_NAME``, i.e. ``[',', '.']`` for ``en-US`` and ``['.', ',']`` for
+ * ``de-DE``. Determined from ``Intl.NumberFormat`` rather than hard-coded, so
+ * that changing the Python ``LOCALE_NAME`` setting is all that is needed to
+ * support another locale.
+ *
+ * @returns {Array} 2-element Array of [group separator, decimal separator]
+ */
+function currency_separators() {
+    var group = ',';
+    var decimal = '.';
+    try {
+        var parts = new Intl.NumberFormat(LOCALE_NAME).formatToParts(11111.1);
+        for (var i = 0; i < parts.length; i++) {
+            if (parts[i].type === 'group') { group = parts[i].value; }
+            if (parts[i].type === 'decimal') { decimal = parts[i].value; }
+        }
+    } catch (e) {
+        // fall back to the en-US defaults above
+    }
+    return [group, decimal];
+}
+
+/**
+ * Parse a user-entered currency string to a Number, or ``null`` if it cannot
+ * be unambiguously interpreted.
+ *
+ * This is the browser counterpart to :js:func:`fmt_currency`, and mirrors
+ * ``biweeklybudget.utils.parse_currency()`` on the server; the server remains
+ * the authority, and this function exists so that in-browser validation does
+ * not reject values the server would accept. See GitHub issue #323.
+ *
+ * For ``en-US``, all of ``1234.56``, ``1,234.56``, ``1 234.56``,
+ * ``$1,234.56`` and ``(1,234.56)`` are interpreted, and bare integers such as
+ * ``123`` are accepted. Ambiguously grouped values such as ``10,00`` return
+ * ``null`` rather than a guess.
+ *
+ * Returns ``null`` and not ``NaN`` deliberately: ``NaN`` comparisons silently
+ * evaluate false, which is how ``parseFloat`` used to disable the Save button
+ * with no visible reason.
+ *
+ * @param {string} value - the string to parse
+ * @returns {(number|null)} the numeric value, or null if not interpretable
+ */
+function parse_currency(value) {
+    if (typeof value !== 'string') { return null; }
+    // normalize unicode spaces (NBSP, thin space, narrow NBSP, figure space)
+    var s = value.replace(/[\t\u00a0\u2007\u2009\u202f]/g, ' ').trim();
+    var negative = false;
+    if (s.length > 1 && s.charAt(0) === '(' &&
+        s.charAt(s.length - 1) === ')') {
+        negative = true;
+        s = s.substring(1, s.length - 1).trim();
+    }
+    // Strip currency symbol, ISO code and sign repeatedly until stable; a
+    // single pass mis-handles "-$1,234.56".
+    var tokens = [CURRENCY_SYMBOL, CURRENCY_CODE];
+    var changed = true;
+    while (changed && s !== '') {
+        changed = false;
+        for (var i = 0; i < tokens.length; i++) {
+            var tok = tokens[i];
+            if (!tok) { continue; }
+            if (s.indexOf(tok) === 0) {
+                s = s.substring(tok.length).trim();
+                changed = true;
+            } else if (s.length >= tok.length &&
+                       s.lastIndexOf(tok) === s.length - tok.length) {
+                s = s.substring(0, s.length - tok.length).trim();
+                changed = true;
+            }
+        }
+        if (s.charAt(0) === '-' || s.charAt(0) === '+') {
+            if (s.charAt(0) === '-') { negative = !negative; }
+            s = s.substring(1).trim();
+            changed = true;
+        }
+    }
+    if (s === '') { return null; }
+    var seps = currency_separators();
+    var group = seps[0];
+    var decimal = seps[1];
+    // Rewrite spaces used as grouping separators into the locale's own
+    // grouping separator rather than deleting them, so that the grouping
+    // check below applies to space-separated input too. Deleting them would
+    // read "1 2 3" as 123.
+    s = s.split(' ').join(group);
+    var parts = s.split(decimal);
+    if (parts.length > 2) { return null; }
+    var intpart = parts[0];
+    var fracpart = parts.length === 2 ? parts[1] : '';
+    if (fracpart !== '' && !/^[0-9]+$/.test(fracpart)) { return null; }
+    // ".5" is a valid amount; "." alone is not
+    if (intpart === '' && fracpart === '') { return null; }
+    if (intpart === '') { intpart = '0'; }
+    // validate digit grouping: either no separators at all, or groups of
+    // exactly 3 after a leading group of 1 to 3
+    var groups = intpart.split(group);
+    if (groups.length === 1) {
+        if (!/^[0-9]+$/.test(groups[0])) { return null; }
+    } else {
+        for (var g = 0; g < groups.length; g++) {
+            if (!/^[0-9]+$/.test(groups[g])) { return null; }
+            if (g === 0) {
+                if (groups[g].length < 1 || groups[g].length > 3) {
+                    return null;
+                }
+            } else if (groups[g].length !== 3) {
+                return null;
+            }
+        }
+    }
+    var num = parseFloat(groups.join('') + (fracpart === '' ? '' : '.' + fracpart));
+    if (isNaN(num)) { return null; }
+    return negative ? -num : num;
+}
+
+/**
  * Format a javascript Date as ISO8601 YYYY-MM-DD
  *
  * @param {Date} d - the date to format

--- a/biweeklybudget/flaskapp/static/js/transactions_modal.js
+++ b/biweeklybudget/flaskapp/static/js/transactions_modal.js
@@ -261,11 +261,19 @@ function validateTransModalSplits() {
             }
             budget_ids.push(bid);
         }
-        if($('#trans_frm_budget_amount_' + rownum).val() != '') {
-            total = total + parseFloat($('#trans_frm_budget_amount_' + rownum).val());
+        var raw = $('#trans_frm_budget_amount_' + rownum).val();
+        if(raw != '') {
+            var split_amt = parse_currency(raw);
+            if(split_amt === null) {
+                return 'Error: Invalid amount: "' + raw + '".';
+            }
+            total = total + split_amt;
         }
     }
-    var amt = parseFloat($('#trans_frm_amount').val());
+    var amt = parse_currency($('#trans_frm_amount').val());
+    // The server reports the real field error for an uninterpretable amount;
+    // don't block the submission with a NaN comparison here.
+    if(amt === null) { return null; }
     // Note: workaround for JS floating point math issues...
     if(amt.toFixed(4) != total.toFixed(4)) {
         return 'Error: Sum of budget allocations (' + total.toFixed(4) + ') must equal transaction amount (' + amt.toFixed(4) + ').';
@@ -336,11 +344,15 @@ function transModalBudgetSplitRowHtml(row_num) {
  */
 function transModalSplitBudgetChanged(row_num) {
     if($('#trans_frm_budget_amount_' + row_num).val() != '') { return null; }
-    var amt = parseFloat($('#trans_frm_amount').val());
+    var amt = parse_currency($('#trans_frm_amount').val());
+    if(amt === null) { return null; }
     var total = 0.0;
     for (var rownum = 0; rownum < $('.budget_split_row').length; rownum++) {
-        if($('#trans_frm_budget_amount_' + rownum).val() != '') {
-            total = total + parseFloat($('#trans_frm_budget_amount_' + rownum).val());
+        var raw = $('#trans_frm_budget_amount_' + rownum).val();
+        if(raw != '') {
+            var split_amt = parse_currency(raw);
+            if(split_amt === null) { return null; }
+            total = total + split_amt;
         }
     }
     var remainder = amt - total;

--- a/biweeklybudget/flaskapp/views/accounts.py
+++ b/biweeklybudget/flaskapp/views/accounts.py
@@ -167,6 +167,8 @@ class AccountFormHandler(FormHandlerView):
     Handle POST /forms/account
     """
 
+    currency_fields = ['credit_limit', 'apr', 'prime_rate_margin']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of
@@ -313,6 +315,8 @@ class AccountTxfrFormHandler(FormHandlerView):
     """
     Handle POST /forms/account_transfer
     """
+
+    currency_fields = ['amount']
 
     def validate(self, data):
         """

--- a/biweeklybudget/flaskapp/views/budgets.py
+++ b/biweeklybudget/flaskapp/views/budgets.py
@@ -170,6 +170,8 @@ class BudgetFormHandler(FormHandlerView):
     Handle POST /forms/budget
     """
 
+    currency_fields = ['starting_balance', 'current_balance']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of
@@ -244,6 +246,8 @@ class BudgetTxfrFormHandler(FormHandlerView):
     """
     Handle POST /forms/budget_transfer
     """
+
+    currency_fields = ['amount']
 
     def validate(self, data):
         """

--- a/biweeklybudget/flaskapp/views/credit_payoffs.py
+++ b/biweeklybudget/flaskapp/views/credit_payoffs.py
@@ -53,6 +53,7 @@ from biweeklybudget.models.account import NoInterestChargedError, Account
 from biweeklybudget.models.ofx_statement import OFXStatement
 from biweeklybudget.models.ofx_transaction import OFXTransaction
 from biweeklybudget.flaskapp.views.formhandlerview import FormHandlerView
+from biweeklybudget.utils import parse_currency, CurrencyParseError
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +201,21 @@ class PayoffSettingsFormHandler(MethodView):
             for d in sorted(data[key], key=lambda k: k['date']):
                 if d['date'] == '' or d['amount'] == '':
                     continue
+                # Normalize on the way in, so the stored JSON is always
+                # canonical. _payment_settings_dict() re-parses these amounts
+                # while *rendering* the credit payoff page, so a bad value
+                # stored here would break the whole page. GitHub issue #323.
+                try:
+                    d['amount'] = str(parse_currency(d['amount']))
+                except CurrencyParseError:
+                    logger.error(
+                        'Invalid %s amount in payoff settings: %s',
+                        key, d['amount']
+                    )
+                    return jsonify({
+                        'success': False,
+                        'error_message': 'Invalid amount: "%s"' % d['amount']
+                    })
                 fixeddata[key].append(d)
         val = json.dumps(fixeddata, sort_keys=True, cls=MagicJSONEncoder)
         logger.info('Changing setting value to: %s', val)
@@ -244,6 +260,8 @@ class AccountOfxFormHandler(FormHandlerView):
     """
     Handle POST /forms/credit-payoff-account-ofx
     """
+
+    currency_fields = ['interest_amt']
 
     def validate(self, data):
         pass

--- a/biweeklybudget/flaskapp/views/formhandlerview.py
+++ b/biweeklybudget/flaskapp/views/formhandlerview.py
@@ -39,12 +39,25 @@ import logging
 from flask.views import MethodView
 from flask import jsonify, request
 from datetime import datetime
-from decimal import Decimal
+
+from biweeklybudget.utils import parse_currency, CurrencyParseError
 
 logger = logging.getLogger(__name__)
 
 
 class FormHandlerView(MethodView):
+
+    #: List of names of form fields that hold currency amounts. Values of these
+    #: fields are normalized to a canonical numeric string by
+    #: :py:meth:`~.normalize_currency` before :py:meth:`~.validate` is called,
+    #: so that user-entered formatting such as ``$1,234.56`` or a bare ``123``
+    #: is accepted everywhere. See GitHub issue #323.
+    currency_fields = []
+
+    #: List of names of form fields that hold non-currency decimal numbers.
+    #: Normalized identically to :py:attr:`~.currency_fields`, but reported
+    #: with "number" rather than "amount" wording when invalid.
+    decimal_fields = []
 
     def post(self):
         """
@@ -61,7 +74,23 @@ class FormHandlerView(MethodView):
         if data is None:
             # not JSON, must be form encoded
             data = request.form.to_dict()
-        res = self.validate(data)
+        errors = self.normalize_currency(data)
+        if errors:
+            logger.info('Currency normalization failed. data=%s errors=%s',
+                        data, errors)
+            return jsonify({
+                'success': False,
+                'errors': errors
+            })
+        try:
+            res = self.validate(data)
+        except Exception as ex:
+            logger.warning('Form validation raised an exception. data=%s',
+                           data, exc_info=True)
+            return jsonify({
+                'success': False,
+                'error_message': str(ex)
+            })
         if res is not None:
             logger.info('Form validation failed. data=%s errors=%s',
                         data, res)
@@ -84,6 +113,45 @@ class FormHandlerView(MethodView):
             'success': True,
             'success_message': res
         })
+
+    def normalize_currency(self, data):
+        """
+        Normalize every field named in :py:attr:`~.currency_fields` and
+        :py:attr:`~.decimal_fields` to a canonical numeric string, in place.
+
+        This is the single place where user-entered currency formatting is
+        interpreted on the server; doing it here, before
+        :py:meth:`~.validate` runs, means every downstream
+        ``Decimal(data[key])`` and ``float(data[key])`` in ``validate()`` and
+        ``submit()`` receives a value it can parse. See GitHub issue #323.
+
+        Fields that are absent from ``data``, that are empty or whitespace
+        only, or that are not strings, are left untouched - each field's
+        existing "blank means zero" or "blank is an error" behavior is
+        unchanged by normalization.
+
+        :param data: submitted form data; modified in place
+        :type data: dict
+        :return: hash of field name to list of error strings for that field;
+          empty if every field was valid
+        :rtype: dict
+        """
+        errors = {}
+        fields = [(k, 'amount') for k in self.currency_fields]
+        fields += [(k, 'number') for k in self.decimal_fields]
+        for key, noun in fields:
+            if key not in data:
+                continue
+            value = data[key]
+            if not isinstance(value, str) or value.strip() == '':
+                continue
+            try:
+                data[key] = str(parse_currency(value))
+            except CurrencyParseError:
+                errors.setdefault(key, []).append(
+                    'Invalid %s: "%s"' % (noun, value)
+                )
+        return errors
 
     def validate(self, data):
         """
@@ -119,7 +187,12 @@ class FormHandlerView(MethodView):
 
     def _validate_float(self, key, data, errors):
         """
-        Validate a float field.
+        Validate a numeric (non-currency) field.
+
+        Accepts anything :py:func:`~biweeklybudget.utils.parse_currency`
+        accepts, which includes bare integers; the previous implementation
+        required a decimal point, rejecting ``123`` while accepting ``123.0``
+        (GitHub issue #323).
 
         :param key: the key in data to look at
         :type key: str
@@ -131,15 +204,18 @@ class FormHandlerView(MethodView):
         :rtype: dict
         """
         try:
-            x = float(data[key])
-            assert data[key].startswith('%s' % x)
+            parse_currency(data[key])
         except Exception:
-            errors[key].append('Invalid float value: "%s"' % data[key])
+            errors[key].append('Invalid number: "%s"' % data[key])
         return errors
 
     def _validate_decimal(self, key, data, errors):
         """
-        Validate a Decimal field.
+        Validate a currency amount field.
+
+        Accepts anything :py:func:`~biweeklybudget.utils.parse_currency`
+        accepts, i.e. bare integers, thousands separators and a currency
+        symbol (GitHub issue #323).
 
         :param key: the key in data to look at
         :type key: str
@@ -151,9 +227,9 @@ class FormHandlerView(MethodView):
         :rtype: dict
         """
         try:
-            Decimal(data[key])
+            parse_currency(data[key])
         except Exception:
-            errors[key].append('Invalid Decimal value: "%s"' % data[key])
+            errors[key].append('Invalid amount: "%s"' % data[key])
         return errors
 
     def _validate_date_ymd(self, key, data, errors):

--- a/biweeklybudget/flaskapp/views/fuel.py
+++ b/biweeklybudget/flaskapp/views/fuel.py
@@ -265,6 +265,9 @@ class FuelLogFormHandler(FormHandlerView):
     Handle POST /forms/fuel
     """
 
+    currency_fields = ['cost_per_gallon', 'total_cost']
+    decimal_fields = ['gallons', 'reported_mpg']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of

--- a/biweeklybudget/flaskapp/views/payperiods.py
+++ b/biweeklybudget/flaskapp/views/payperiods.py
@@ -233,6 +233,8 @@ class SchedToTransFormHandler(FormHandlerView):
     Handle POST /forms/sched_to_trans
     """
 
+    currency_fields = ['amount', 'sales_tax']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of
@@ -303,6 +305,8 @@ class SkipSchedTransFormHandler(FormHandlerView):
     """
     Handle POST /forms/skip_sched_trans
     """
+
+    currency_fields = ['amount']
 
     def validate(self, data):
         """

--- a/biweeklybudget/flaskapp/views/projects.py
+++ b/biweeklybudget/flaskapp/views/projects.py
@@ -402,6 +402,8 @@ class BoMItemFormHandler(FormHandlerView):
     Handle POST /forms/bom_item
     """
 
+    currency_fields = ['unit_cost']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of

--- a/biweeklybudget/flaskapp/views/scheduled.py
+++ b/biweeklybudget/flaskapp/views/scheduled.py
@@ -213,6 +213,8 @@ class SchedTransFormHandler(FormHandlerView):
     Handle POST /forms/scheduled
     """
 
+    currency_fields = ['amount', 'sales_tax']
+
     def validate(self, data):
         """
         Validate the form data. Return None if it is valid, or else a hash of

--- a/biweeklybudget/flaskapp/views/transactions.py
+++ b/biweeklybudget/flaskapp/views/transactions.py
@@ -51,6 +51,7 @@ from biweeklybudget.models.account import Account
 from biweeklybudget.models.budget_model import Budget
 from biweeklybudget.flaskapp.views.searchableajaxview import SearchableAjaxView
 from biweeklybudget.flaskapp.views.formhandlerview import FormHandlerView
+from biweeklybudget.utils import parse_currency, CurrencyParseError
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +258,38 @@ class TransactionFormHandler(FormHandlerView):
     """
     Handle POST /forms/transaction
     """
+
+    currency_fields = ['amount', 'sales_tax']
+
+    def normalize_currency(self, data):
+        """
+        Normalize the currency fields, plus the per-budget split amounts.
+
+        Budget split amounts arrive as a ``budgets`` hash of budget ID to
+        amount, which :py:attr:`~.FormHandlerView.currency_fields` cannot
+        address; they are normalized here so that :py:meth:`~.validate` can
+        sum them. See GitHub issue #323.
+
+        :param data: submitted form data; modified in place
+        :type data: dict
+        :return: hash of field name to list of error strings for that field;
+          empty if every field was valid
+        :rtype: dict
+        """
+        errors = super().normalize_currency(data)
+        budgets = data.get('budgets', None)
+        if not isinstance(budgets, dict):
+            return errors
+        for bid, amount in budgets.items():
+            if not isinstance(amount, str) or amount.strip() == '':
+                continue
+            try:
+                budgets[bid] = str(parse_currency(amount))
+            except CurrencyParseError:
+                errors.setdefault('budgets', []).append(
+                    'Invalid amount: "%s"' % amount
+                )
+        return errors
 
     def validate(self, data):
         """

--- a/biweeklybudget/tests/acceptance/flaskapp/views/test_currency_normalization.py
+++ b/biweeklybudget/tests/acceptance/flaskapp/views/test_currency_normalization.py
@@ -1,0 +1,676 @@
+"""
+The latest version of this package is available at:
+<http://github.com/jantman/biweeklybudget>
+
+################################################################################
+Copyright 2016-2024 Jason Antman <http://www.jasonantman.com>
+
+    This file is part of biweeklybudget, also known as biweeklybudget.
+
+    biweeklybudget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    biweeklybudget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with biweeklybudget.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/biweeklybudget> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import pytest
+import requests
+from decimal import Decimal
+from datetime import timedelta
+
+from biweeklybudget.utils import dtnow
+from biweeklybudget.biweeklypayperiod import BiweeklyPayPeriod
+from biweeklybudget.tests.acceptance_helpers import AcceptanceHelper
+from biweeklybudget.models.account import Account
+from biweeklybudget.models.budget_model import Budget
+from biweeklybudget.models.projects import BoMItem
+from biweeklybudget.models.fuel import FuelFill
+from biweeklybudget.models.scheduled_transaction import ScheduledTransaction
+from biweeklybudget.models.transaction import Transaction
+from biweeklybudget.models.dbsetting import DBSetting
+
+
+@pytest.mark.acceptance
+@pytest.mark.usefixtures('class_refresh_db', 'refreshdb', 'testflask')
+@pytest.mark.incremental
+class TestCurrencyNormalizationAcrossForms(AcceptanceHelper):
+    """
+    Every currency input in the application must accept common formatting;
+    GitHub issue #323. This covers the forms whose client-side behavior is not
+    itself affected by the change - the Transaction modal, which is, has
+    dedicated browser tests in ``test_transactions.py``.
+
+    Each test posts a separator-formatted value to a real form endpoint over
+    HTTP and asserts the value actually persisted.
+    """
+
+    def test_01_budget_starting_balance(self, base_url):
+        res = requests.post(
+            base_url + '/forms/budget',
+            json={
+                'id': '',
+                'name': 'CommaBudget',
+                'description': 'comma',
+                'is_periodic': True,
+                'starting_balance': '$1,234.56',
+                'current_balance': '',
+                'is_active': True,
+                'is_income': False,
+                'omit_from_graphs': False
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_02_verify_budget_starting_balance(self, testdb):
+        b = testdb.query(Budget).filter(
+            Budget.name.__eq__('CommaBudget')
+        ).one()
+        assert b.starting_balance == Decimal('1234.56')
+
+    def test_03_budget_bare_integer_balance(self, base_url):
+        res = requests.post(
+            base_url + '/forms/budget',
+            json={
+                'id': '',
+                'name': 'IntBudget',
+                'description': 'int',
+                'is_periodic': False,
+                'starting_balance': '',
+                'current_balance': '1234',
+                'is_active': True,
+                'is_income': False,
+                'omit_from_graphs': False
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_04_verify_budget_bare_integer_balance(self, testdb):
+        b = testdb.query(Budget).filter(
+            Budget.name.__eq__('IntBudget')
+        ).one()
+        assert b.current_balance == Decimal('1234')
+
+    def test_05_budget_invalid_balance(self, base_url):
+        res = requests.post(
+            base_url + '/forms/budget',
+            json={
+                'id': '',
+                'name': 'BadBudget',
+                'description': 'bad',
+                'is_periodic': True,
+                'starting_balance': '10,00',
+                'current_balance': '',
+                'is_active': True,
+                'is_income': False,
+                'omit_from_graphs': False
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {
+            'starting_balance': ['Invalid amount: "10,00"']
+        }
+
+    def test_06_verify_invalid_budget_not_saved(self, testdb):
+        assert testdb.query(Budget).filter(
+            Budget.name.__eq__('BadBudget')
+        ).all() == []
+
+    def test_10_budget_transfer(self, base_url):
+        res = requests.post(
+            base_url + '/forms/budget_transfer',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '$1,234.56',
+                'notes': 'BudgetTransferComma',
+                'account': '1',
+                'from_budget': '4',
+                'to_budget': '5'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_11_verify_budget_transfer(self, testdb):
+        txns = testdb.query(Transaction).filter(
+            Transaction.notes.__eq__('BudgetTransferComma')
+        ).all()
+        assert len(txns) == 2
+        assert sorted([t.actual_amount for t in txns]) == [
+            Decimal('-1234.56'), Decimal('1234.56')
+        ]
+
+    def test_20_account_transfer(self, base_url):
+        res = requests.post(
+            base_url + '/forms/account_transfer',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '1 234.56',
+                'notes': 'AcctTransferSpace',
+                'budget': '1',
+                'from_account': '1',
+                'to_account': '2'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_21_verify_account_transfer(self, testdb):
+        txns = testdb.query(Transaction).filter(
+            Transaction.notes.__eq__('AcctTransferSpace')
+        ).all()
+        assert len(txns) == 2
+        assert sorted([t.actual_amount for t in txns]) == [
+            Decimal('-1234.56'), Decimal('1234.56')
+        ]
+
+    def test_30_account_credit_limit_and_rates(self, base_url, testdb):
+        acct = testdb.query(Account).get(3)
+        res = requests.post(
+            base_url + '/forms/account',
+            json={
+                'id': '3',
+                'name': acct.name,
+                'description': acct.description or '',
+                'acct_type': 'Credit',
+                'ofx_cat_memo_to_name': False,
+                'vault_creds_path': '',
+                'ofxgetter_config_json': '',
+                'negate_ofx_amounts': False,
+                'reconcile_trans': True,
+                're_interest_charge': '',
+                're_interest_paid': '',
+                're_payment': '',
+                're_late_fee': '',
+                're_other_fee': '',
+                'credit_limit': '$12,345',
+                'apr': '0.1000',
+                'prime_rate_margin': '0.0050',
+                'interest_class_name': 'AdbCompoundedDaily',
+                'min_payment_class_name': 'MinPaymentAmEx',
+                'is_active': True,
+                'plaid_account': 'null,null'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_31_verify_account_credit_limit(self, testdb):
+        acct = testdb.query(Account).get(3)
+        assert acct.credit_limit == Decimal('12345')
+
+    def test_40_bom_item_bare_integer_unit_cost(self, base_url):
+        res = requests.post(
+            base_url + '/forms/bom_item',
+            json={
+                'id': '',
+                'project_id': '1',
+                'name': 'IntCostItem',
+                'notes': '',
+                'quantity': '2',
+                'unit_cost': '40',
+                'url': '',
+                'is_active': True
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_41_verify_bom_item_bare_integer_unit_cost(self, testdb):
+        item = testdb.query(BoMItem).filter(
+            BoMItem.name.__eq__('IntCostItem')
+        ).one()
+        assert item.unit_cost == Decimal('40')
+
+    def test_42_bom_item_comma_unit_cost(self, base_url):
+        res = requests.post(
+            base_url + '/forms/bom_item',
+            json={
+                'id': '',
+                'project_id': '1',
+                'name': 'CommaCostItem',
+                'notes': '',
+                'quantity': '1',
+                'unit_cost': '$1,234.56',
+                'url': '',
+                'is_active': True
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_43_verify_bom_item_comma_unit_cost(self, testdb):
+        item = testdb.query(BoMItem).filter(
+            BoMItem.name.__eq__('CommaCostItem')
+        ).one()
+        assert item.unit_cost == Decimal('1234.56')
+
+    def test_44_bom_item_invalid_unit_cost(self, base_url):
+        res = requests.post(
+            base_url + '/forms/bom_item',
+            json={
+                'id': '',
+                'project_id': '1',
+                'name': 'BadCostItem',
+                'notes': '',
+                'quantity': '1',
+                'unit_cost': 'abc',
+                'url': '',
+                'is_active': True
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {'unit_cost': ['Invalid amount: "abc"']}
+
+    def test_50_fuel_fill_bare_integers(self, base_url):
+        res = requests.post(
+            base_url + '/forms/fuel',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'vehicle': '1',
+                'odometer_miles': '1111',
+                'reported_miles': '100',
+                'level_before': '10',
+                'level_after': '100',
+                'fill_location': 'IntFill',
+                'cost_per_gallon': '3',
+                'total_cost': '30',
+                'gallons': '10',
+                'reported_mpg': '10',
+                'notes': '',
+                'add_trans': False,
+                'account': 'None',
+                'budget': 'None'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_51_verify_fuel_fill_bare_integers(self, testdb):
+        f = testdb.query(FuelFill).filter(
+            FuelFill.fill_location.__eq__('IntFill')
+        ).one()
+        assert f.cost_per_gallon == Decimal('3')
+        assert f.total_cost == Decimal('30')
+        assert f.gallons == Decimal('10')
+        assert f.reported_mpg == Decimal('10')
+
+    def test_52_fuel_fill_comma_total(self, base_url):
+        res = requests.post(
+            base_url + '/forms/fuel',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'vehicle': '1',
+                'odometer_miles': '1211',
+                'reported_miles': '100',
+                'level_before': '10',
+                'level_after': '100',
+                'fill_location': 'CommaFill',
+                'cost_per_gallon': '$3.50',
+                'total_cost': '$1,234.56',
+                'gallons': '10.5',
+                'reported_mpg': '10.5',
+                'notes': '',
+                'add_trans': False,
+                'account': 'None',
+                'budget': 'None'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_53_verify_fuel_fill_comma_total(self, testdb):
+        f = testdb.query(FuelFill).filter(
+            FuelFill.fill_location.__eq__('CommaFill')
+        ).one()
+        assert f.total_cost == Decimal('1234.56')
+        assert f.cost_per_gallon == Decimal('3.50')
+
+    def test_54_fuel_fill_invalid_gallons_uses_number_wording(self, base_url):
+        res = requests.post(
+            base_url + '/forms/fuel',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'vehicle': '1',
+                'odometer_miles': '1311',
+                'reported_miles': '100',
+                'level_before': '10',
+                'level_after': '100',
+                'fill_location': 'BadFill',
+                'cost_per_gallon': '3',
+                'total_cost': '30',
+                'gallons': 'abc',
+                'reported_mpg': '10',
+                'notes': '',
+                'add_trans': False,
+                'account': 'None',
+                'budget': 'None'
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {'gallons': ['Invalid number: "abc"']}
+
+    def test_55_verify_invalid_fuel_fill_not_saved(self, testdb):
+        assert testdb.query(FuelFill).filter(
+            FuelFill.fill_location.__eq__('BadFill')
+        ).all() == []
+
+    def test_60_scheduled_transaction(self, base_url):
+        res = requests.post(
+            base_url + '/forms/scheduled',
+            json={
+                'id': '',
+                'description': 'CommaSched',
+                'type': 'monthly',
+                'day_of_month': '4',
+                'amount': '$1,234.56',
+                'sales_tax': '89',
+                'account': '1',
+                'budget': '1',
+                'notes': '',
+                'is_active': True
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_61_verify_scheduled_transaction(self, testdb):
+        st = testdb.query(ScheduledTransaction).filter(
+            ScheduledTransaction.description.__eq__('CommaSched')
+        ).one()
+        assert st.amount == Decimal('1234.56')
+        assert st.sales_tax == Decimal('89')
+
+    def test_62_scheduled_transaction_invalid_amount(self, base_url):
+        res = requests.post(
+            base_url + '/forms/scheduled',
+            json={
+                'id': '',
+                'description': 'BadSched',
+                'type': 'monthly',
+                'day_of_month': '4',
+                'amount': '1,23,4.56',
+                'sales_tax': '',
+                'account': '1',
+                'budget': '1',
+                'notes': '',
+                'is_active': True
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {'amount': ['Invalid amount: "1,23,4.56"']}
+
+    def test_63_verify_invalid_scheduled_not_saved(self, testdb):
+        assert testdb.query(ScheduledTransaction).filter(
+            ScheduledTransaction.description.__eq__('BadSched')
+        ).all() == []
+
+    def test_70_payoff_settings_normalized_on_write(self, base_url):
+        res = requests.post(
+            base_url + '/settings/credit-payoff',
+            json={
+                'increases': [
+                    {
+                        'enabled': True,
+                        'date': (
+                            dtnow() + timedelta(days=30)
+                        ).strftime('%Y-%m-%d'),
+                        'amount': '$1,234.56'
+                    }
+                ],
+                'onetimes': [
+                    {
+                        'enabled': True,
+                        'date': (
+                            dtnow() + timedelta(days=60)
+                        ).strftime('%Y-%m-%d'),
+                        'amount': '2,000'
+                    }
+                ]
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_71_verify_payoff_settings_stored_canonical(self, testdb):
+        import json
+        setting = testdb.query(DBSetting).get('credit-payoff')
+        val = json.loads(setting.value)
+        assert val['increases'][0]['amount'] == '1234.56'
+        assert val['onetimes'][0]['amount'] == '2000'
+        # the stored value must be directly parseable, because the credit
+        # payoff page re-parses it while rendering
+        assert Decimal(val['increases'][0]['amount']) == Decimal('1234.56')
+
+    def test_72_payoff_settings_invalid_amount(self, base_url):
+        res = requests.post(
+            base_url + '/settings/credit-payoff',
+            json={
+                'increases': [
+                    {
+                        'enabled': True,
+                        'date': (
+                            dtnow() + timedelta(days=30)
+                        ).strftime('%Y-%m-%d'),
+                        'amount': '10,00'
+                    }
+                ],
+                'onetimes': []
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['error_message'] == 'Invalid amount: "10,00"'
+
+    def test_73_verify_payoff_settings_unchanged(self, testdb):
+        import json
+        setting = testdb.query(DBSetting).get('credit-payoff')
+        val = json.loads(setting.value)
+        # still the value stored by test_70, not the rejected one
+        assert val['increases'][0]['amount'] == '1234.56'
+
+    def test_80_sched_to_trans(self, base_url, testdb):
+        st = testdb.query(ScheduledTransaction).get(1)
+        pp = BiweeklyPayPeriod.period_for_date(dtnow().date(), testdb)
+        res = requests.post(
+            base_url + '/forms/sched_to_trans',
+            json={
+                'id': str(st.id),
+                'payperiod_start_date': pp.start_date.strftime('%Y-%m-%d'),
+                'date': pp.start_date.strftime('%Y-%m-%d'),
+                'amount': '$1,234.56',
+                'sales_tax': '89',
+                'description': 'SchedToTransComma',
+                'notes': ''
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_81_verify_sched_to_trans(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('SchedToTransComma')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+        assert t.sales_tax == Decimal('89')
+
+    def test_82_sched_to_trans_invalid_amount(self, base_url, testdb):
+        st = testdb.query(ScheduledTransaction).get(1)
+        pp = BiweeklyPayPeriod.period_for_date(dtnow().date(), testdb)
+        res = requests.post(
+            base_url + '/forms/sched_to_trans',
+            json={
+                'id': str(st.id),
+                'payperiod_start_date': pp.start_date.strftime('%Y-%m-%d'),
+                'date': pp.start_date.strftime('%Y-%m-%d'),
+                'amount': '1.2.3',
+                'sales_tax': '',
+                'description': 'SchedToTransBad',
+                'notes': ''
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {'amount': ['Invalid amount: "1.2.3"']}
+
+    def test_83_verify_invalid_sched_to_trans_not_saved(self, testdb):
+        assert testdb.query(Transaction).filter(
+            Transaction.description.__eq__('SchedToTransBad')
+        ).all() == []
+
+    def test_90_skip_sched_trans(self, base_url, testdb):
+        st = testdb.query(ScheduledTransaction).get(2)
+        pp = BiweeklyPayPeriod.period_for_date(dtnow().date(), testdb)
+        res = requests.post(
+            base_url + '/forms/skip_sched_trans',
+            json={
+                'id': str(st.id),
+                'payperiod_start_date': pp.start_date.strftime('%Y-%m-%d'),
+                'date': pp.start_date.strftime('%Y-%m-%d'),
+                'amount': '1,234.56',
+                'description': 'SkipSchedComma',
+                'notes': 'SkipSchedComma'
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_91_verify_skip_sched_trans(self, testdb):
+        # the skip record is always created with a zero amount; what matters
+        # here is that the comma-formatted amount passed validation instead of
+        # raising out of validate()
+        assert testdb.query(Transaction).filter(
+            Transaction.notes.__eq__('SkipSchedComma')
+        ).one() is not None
+
+    def test_92_skip_sched_trans_invalid_amount(self, base_url, testdb):
+        st = testdb.query(ScheduledTransaction).get(3)
+        pp = BiweeklyPayPeriod.period_for_date(dtnow().date(), testdb)
+        res = requests.post(
+            base_url + '/forms/skip_sched_trans',
+            json={
+                'id': str(st.id),
+                'payperiod_start_date': pp.start_date.strftime('%Y-%m-%d'),
+                'date': pp.start_date.strftime('%Y-%m-%d'),
+                'amount': '10,00',
+                'description': 'SkipSchedBad',
+                'notes': 'SkipSchedBad'
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors'] == {'amount': ['Invalid amount: "10,00"']}
+
+
+@pytest.mark.acceptance
+@pytest.mark.usefixtures('class_refresh_db', 'refreshdb', 'testflask')
+class TestCurrencyNormalizationDoesNotChangeExistingBehavior(AcceptanceHelper):
+    """
+    Normalization widens what is accepted; it must not narrow it, and it must
+    not disturb each field's existing blank-value semantics (FR-010).
+    """
+
+    def test_blank_optional_currency_field_still_allowed(self, base_url):
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '100.00',
+                'description': 'BlankSalesTax',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': '100.00'},
+                'sales_tax': ''
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_zero_amount_still_rejected(self, base_url):
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '0',
+                'description': 'ZeroAmount',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': '0'},
+                'sales_tax': ''
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors']['amount'] == ['Amount cannot be zero']
+
+    def test_negative_zero_still_counts_as_zero(self, base_url):
+        # "-0.00" normalizes to 0.00, so the zero check must still fire
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '-0.00',
+                'description': 'NegZeroAmount',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': '-0.00'},
+                'sales_tax': ''
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors']['amount'] == ['Amount cannot be zero']
+
+    def test_empty_required_amount_is_not_a_server_error(self, base_url):
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '',
+                'description': 'EmptyAmount',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': ''},
+                'sales_tax': ''
+            }
+        )
+        # a blank required amount is left for validate() to handle; whatever
+        # it decides, it must not be a 500
+        assert res.status_code == 200
+        assert res.json()['success'] is False

--- a/biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py
+++ b/biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py
@@ -2043,3 +2043,292 @@ class TestTransModalBudgetSplits(AcceptanceHelper):
         assert max([
             tx.id for tx in testdb.query(Transaction).all()
         ]) == 5
+
+
+@pytest.mark.acceptance
+@pytest.mark.usefixtures('class_refresh_db', 'refreshdb', 'testflask')
+@pytest.mark.incremental
+class TestTransModalCurrencyNormalization(AcceptanceHelper):
+    """
+    Browser tests for currency input normalization; GitHub issue #323.
+
+    Entering ``1,234.56`` used to produce a 500 Internal Server Error, and a
+    bare ``123`` used to be rejected as an invalid value.
+    """
+
+    def _add_transaction(self, base_url, selenium, amount, description,
+                         sales_tax=None):
+        """
+        Fill and submit the Add Transaction modal with the given amount, and
+        return the text of the first div in the modal body afterwards.
+        """
+        self.baseurl = base_url
+        self.get(selenium, base_url + '/transactions')
+        link = selenium.find_element(By.ID, 'btn_add_trans')
+        modal, title, body = self.try_click_and_get_modal(selenium, link)
+        self.assert_modal_displayed(modal, title, body)
+        assert title.text == 'Add New Transaction'
+        amt = body.find_element(By.ID, 'trans_frm_amount')
+        amt.clear()
+        amt.send_keys(amount)
+        desc = body.find_element(By.ID, 'trans_frm_description')
+        desc.send_keys(description)
+        Select(
+            body.find_element(By.ID, 'trans_frm_account')
+        ).select_by_value('1')
+        Select(
+            body.find_element(By.ID, 'trans_frm_budget')
+        ).select_by_value('1')
+        if sales_tax is not None:
+            tax = body.find_element(By.ID, 'trans_frm_sales_tax')
+            tax.clear()
+            tax.send_keys(sales_tax)
+        selenium.find_element(By.ID, 'modalSaveButton').click()
+        self.wait_for_jquery_done(selenium)
+        _, _, body = self.get_modal_parts(selenium)
+        return body
+
+    def test_01_comma_separated_amount(self, base_url, selenium):
+        """Entering "1,234.56" must save, not raise a 500."""
+        body = self._add_transaction(
+            base_url, selenium, '1,234.56', 'CommaAmount'
+        )
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_02_verify_comma_separated_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('CommaAmount')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+        assert t.budget_transactions[0].amount == Decimal('1234.56')
+
+    def test_03_bare_integer_amount(self, base_url, selenium):
+        """Entering "123" must save; it used to require "123.0"."""
+        body = self._add_transaction(
+            base_url, selenium, '123', 'BareInteger', sales_tax='7'
+        )
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_04_verify_bare_integer_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('BareInteger')
+        ).one()
+        assert t.actual_amount == Decimal('123')
+        assert t.sales_tax == Decimal('7')
+
+    def test_05_currency_symbol_amount(self, base_url, selenium):
+        body = self._add_transaction(
+            base_url, selenium, '$1,234.56', 'SymbolAmount'
+        )
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_06_verify_currency_symbol_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('SymbolAmount')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+
+    def test_07_space_separated_amount(self, base_url, selenium):
+        body = self._add_transaction(
+            base_url, selenium, ' 1 234.56 ', 'SpaceAmount'
+        )
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_08_verify_space_separated_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('SpaceAmount')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+
+    def test_09_parenthesized_negative_amount(self, base_url, selenium):
+        body = self._add_transaction(
+            base_url, selenium, '(1,234.56)', 'ParenAmount'
+        )
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_10_verify_parenthesized_negative_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('ParenAmount')
+        ).one()
+        assert t.actual_amount == Decimal('-1234.56')
+
+    def test_20_invalid_amount_shows_field_error(self, base_url, selenium):
+        """Malformed input must produce a field error, never a 500."""
+        self.baseurl = base_url
+        self.get(selenium, base_url + '/transactions')
+        link = selenium.find_element(By.ID, 'btn_add_trans')
+        modal, title, body = self.try_click_and_get_modal(selenium, link)
+        self.assert_modal_displayed(modal, title, body)
+        amt = body.find_element(By.ID, 'trans_frm_amount')
+        amt.clear()
+        amt.send_keys('abc')
+        desc = body.find_element(By.ID, 'trans_frm_description')
+        desc.send_keys('ShouldNotBeSaved')
+        Select(
+            body.find_element(By.ID, 'trans_frm_account')
+        ).select_by_value('1')
+        Select(
+            body.find_element(By.ID, 'trans_frm_budget')
+        ).select_by_value('1')
+        selenium.find_element(By.ID, 'modalSaveButton').click()
+        self.wait_for_jquery_done(selenium)
+        _, _, body = self.get_modal_parts(selenium)
+        # the modal is still the form, not a success alert
+        assert 'Invalid amount: "abc"' in body.text
+        assert 'alert-success' not in body.get_attribute('innerHTML')
+
+    def test_21_verify_invalid_amount_not_saved(self, testdb):
+        assert testdb.query(Transaction).filter(
+            Transaction.description.__eq__('ShouldNotBeSaved')
+        ).all() == []
+
+    def test_30_post_comma_amount_is_not_a_server_error(self, base_url):
+        """
+        The reported bug, at the HTTP level: this used to be a 500.
+        """
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': '1,234.56',
+                'description': 'PostedCommaAmount',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': '1,234.56'},
+                'sales_tax': ''
+            }
+        )
+        assert res.status_code == 200
+        assert res.json()['success'] is True
+
+    def test_31_verify_posted_comma_amount(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('PostedCommaAmount')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+        assert t.budget_transactions[0].amount == Decimal('1234.56')
+
+    @pytest.mark.parametrize(
+        'amount', ['abc', '1.2.3', '10,00', '1,23,4.56']
+    )
+    def test_32_post_invalid_amount_is_not_a_server_error(
+        self, base_url, amount
+    ):
+        """
+        Ambiguous grouping such as "10,00" must be rejected rather than
+        silently read as 1000.
+        """
+        res = requests.post(
+            base_url + '/forms/transaction',
+            json={
+                'date': dtnow().strftime('%Y-%m-%d'),
+                'amount': amount,
+                'description': 'InvalidPost',
+                'notes': '',
+                'account': '1',
+                'budgets': {'1': amount},
+                'sales_tax': ''
+            }
+        )
+        assert res.status_code == 200
+        j = res.json()
+        assert j['success'] is False
+        assert j['errors']['amount'] == ['Invalid amount: "%s"' % amount]
+
+    def test_33_verify_invalid_posts_not_saved(self, testdb):
+        assert testdb.query(Transaction).filter(
+            Transaction.description.__eq__('InvalidPost')
+        ).all() == []
+
+
+@pytest.mark.acceptance
+@pytest.mark.usefixtures('class_refresh_db', 'refreshdb', 'testflask')
+@pytest.mark.incremental
+class TestTransModalSplitCurrencyNormalization(AcceptanceHelper):
+    """
+    Browser tests for the client-side currency parser used by budget split
+    validation; GitHub issue #323. ``parseFloat('1,234.56')`` is ``1``, so
+    before this change the in-browser check disabled Save and the user could
+    never reach the server.
+    """
+
+    def test_01_split_validation_accepts_separators(self, base_url, selenium):
+        self.baseurl = base_url
+        self.get(selenium, base_url + '/transactions')
+        link = selenium.find_element(By.ID, 'btn_add_trans')
+        modal, title, body = self.try_click_and_get_modal(selenium, link)
+        self.assert_modal_displayed(modal, title, body)
+        amt = body.find_element(By.ID, 'trans_frm_amount')
+        amt.clear()
+        amt.send_keys('1,234.56')
+        desc = body.find_element(By.ID, 'trans_frm_description')
+        desc.send_keys('SplitCommaAmount')
+        Select(
+            body.find_element(By.ID, 'trans_frm_account')
+        ).select_by_value('1')
+        selenium.find_element(By.ID, 'trans_frm_is_split').click()
+        Select(
+            body.find_element(By.ID, 'trans_frm_budget_0')
+        ).select_by_value('1')
+        tmp = body.find_element(By.ID, 'trans_frm_budget_amount_0')
+        tmp.clear()
+        tmp.send_keys('1,000.00')
+        Select(
+            body.find_element(By.ID, 'trans_frm_budget_1')
+        ).select_by_value('2')
+        tmp = body.find_element(By.ID, 'trans_frm_budget_amount_1')
+        tmp.clear()
+        tmp.send_keys('234.56')
+        # blur the last field so the split validation runs
+        body.find_element(By.ID, 'trans_frm_description').click()
+        self.wait_for_jquery_done(selenium)
+        assert selenium.find_element(
+            By.ID, 'budget-split-feedback'
+        ).text == ''
+        assert selenium.find_element(By.ID, 'modalSaveButton').is_enabled()
+        selenium.find_element(By.ID, 'modalSaveButton').click()
+        self.wait_for_jquery_done(selenium)
+        _, _, body = self.get_modal_parts(selenium)
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+
+    def test_02_verify_split_amounts(self, testdb):
+        t = testdb.query(Transaction).filter(
+            Transaction.description.__eq__('SplitCommaAmount')
+        ).one()
+        assert t.actual_amount == Decimal('1234.56')
+        assert {
+            bt.budget_id: bt.amount for bt in t.budget_transactions
+        } == {
+            1: Decimal('1000.00'),
+            2: Decimal('234.56')
+        }
+
+    def test_10_split_remainder_autofill_uses_normalized_amount(
+        self, base_url, selenium
+    ):
+        """
+        Selecting a budget auto-fills the remainder. With parseFloat, a
+        transaction amount of "1,234.56" made the remainder 1.00.
+        """
+        self.baseurl = base_url
+        self.get(selenium, base_url + '/transactions')
+        link = selenium.find_element(By.ID, 'btn_add_trans')
+        modal, title, body = self.try_click_and_get_modal(selenium, link)
+        self.assert_modal_displayed(modal, title, body)
+        amt = body.find_element(By.ID, 'trans_frm_amount')
+        amt.clear()
+        amt.send_keys('1,234.56')
+        selenium.find_element(By.ID, 'trans_frm_is_split').click()
+        Select(
+            body.find_element(By.ID, 'trans_frm_budget_0')
+        ).select_by_value('1')
+        self.wait_for_jquery_done(selenium)
+        assert body.find_element(
+            By.ID, 'trans_frm_budget_amount_0'
+        ).get_attribute('value') == '1234.56'

--- a/biweeklybudget/tests/unit/flaskapp/views/test_formhandlerview.py
+++ b/biweeklybudget/tests/unit/flaskapp/views/test_formhandlerview.py
@@ -1,0 +1,167 @@
+"""
+The latest version of this package is available at:
+<http://github.com/jantman/biweeklybudget>
+
+################################################################################
+Copyright 2016-2024 Jason Antman <http://www.jasonantman.com>
+
+    This file is part of biweeklybudget, also known as biweeklybudget.
+
+    biweeklybudget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    biweeklybudget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with biweeklybudget.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/biweeklybudget> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import pytest
+
+from biweeklybudget.flaskapp.views.formhandlerview import FormHandlerView
+
+
+class StubFormHandler(FormHandlerView):
+    """
+    Minimal concrete FormHandlerView, for testing the normalization hook in
+    isolation from any real form or database.
+    """
+
+    currency_fields = ['amount', 'sales_tax']
+    decimal_fields = ['gallons']
+
+    def validate(self, data):
+        return None
+
+    def submit(self, data):
+        return 'submitted'
+
+
+class TestNormalizeCurrency(object):
+    """
+    Tests for :py:meth:`~.FormHandlerView.normalize_currency`; see GitHub
+    issue #323.
+    """
+
+    def setup_method(self):
+        self.cls = StubFormHandler()
+
+    def test_no_declared_fields_is_a_no_op(self):
+        class NoFields(StubFormHandler):
+            currency_fields = []
+            decimal_fields = []
+
+        data = {'amount': '1,234.56'}
+        assert NoFields().normalize_currency(data) == {}
+        assert data == {'amount': '1,234.56'}
+
+    def test_canonicalizes_currency_field(self):
+        data = {'amount': '$1,234.56'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'amount': '1234.56'}
+
+    def test_canonicalizes_bare_integer(self):
+        # github issue #323: must stay integral, not become "123.0"
+        data = {'amount': '123'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'amount': '123'}
+
+    def test_canonicalizes_parenthesized_negative(self):
+        data = {'amount': '(1,234.56)'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'amount': '-1234.56'}
+
+    def test_canonicalizes_decimal_field(self):
+        data = {'gallons': '1,234.56'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'gallons': '1234.56'}
+
+    def test_absent_field_is_skipped(self):
+        data = {'description': 'foo'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'description': 'foo'}
+
+    @pytest.mark.parametrize('value', ['', '   ', '\t'])
+    def test_blank_value_is_left_untouched(self, value):
+        # blank handling belongs to each field's own validate(); normalization
+        # must not turn "optional and empty" into an error
+        data = {'amount': value}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'amount': value}
+
+    @pytest.mark.parametrize('value', [None, 123, 12.3, ['1'], {'a': 1}])
+    def test_non_string_value_is_left_untouched(self, value):
+        data = {'amount': value}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'amount': value}
+
+    def test_undeclared_field_is_not_normalized(self):
+        data = {'notes': '1,234.56'}
+        assert self.cls.normalize_currency(data) == {}
+        assert data == {'notes': '1,234.56'}
+
+    def test_invalid_currency_value_reports_amount_wording(self):
+        data = {'amount': 'abc'}
+        assert self.cls.normalize_currency(data) == {
+            'amount': ['Invalid amount: "abc"']
+        }
+        # the raw value is left in place for the error message and redisplay
+        assert data == {'amount': 'abc'}
+
+    def test_invalid_decimal_value_reports_number_wording(self):
+        data = {'gallons': 'abc'}
+        assert self.cls.normalize_currency(data) == {
+            'gallons': ['Invalid number: "abc"']
+        }
+
+    def test_errors_accumulate_across_fields(self):
+        # all bad fields are reported at once, not just the first
+        data = {'amount': 'abc', 'sales_tax': '1.2.3', 'gallons': '10,00'}
+        assert self.cls.normalize_currency(data) == {
+            'amount': ['Invalid amount: "abc"'],
+            'sales_tax': ['Invalid amount: "1.2.3"'],
+            'gallons': ['Invalid number: "10,00"'],
+        }
+
+    def test_good_fields_normalized_even_when_another_is_bad(self):
+        data = {'amount': '1,234.56', 'sales_tax': 'abc'}
+        errors = self.cls.normalize_currency(data)
+        assert list(errors.keys()) == ['sales_tax']
+        assert data['amount'] == '1234.56'
+
+    def test_ambiguous_grouping_is_rejected_not_guessed(self):
+        # a lenient parser reads this as 1000; silently doing so would corrupt
+        # a financial record, so it must be an error instead
+        data = {'amount': '10,00'}
+        assert self.cls.normalize_currency(data) == {
+            'amount': ['Invalid amount: "10,00"']
+        }
+        assert data == {'amount': '10,00'}
+
+    def test_normalized_value_is_parseable_downstream(self):
+        # the whole point: validate()/submit() call Decimal() and float() on
+        # these values directly
+        from decimal import Decimal
+        data = {'amount': '$1,234.56', 'gallons': '10'}
+        assert self.cls.normalize_currency(data) == {}
+        assert Decimal(data['amount']) == Decimal('1234.56')
+        assert float(data['gallons']) == 10.0

--- a/biweeklybudget/tests/unit/test_utils.py
+++ b/biweeklybudget/tests/unit/test_utils.py
@@ -35,9 +35,14 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
-from biweeklybudget.utils import dtnow, plaid_client
+import pytest
+
+from biweeklybudget.utils import (
+    dtnow, plaid_client, parse_currency, CurrencyParseError
+)
 from pytz import utc
 from datetime import datetime
+from decimal import Decimal
 from freezegun import freeze_time
 
 from unittest.mock import patch, call, Mock, DEFAULT
@@ -99,3 +104,163 @@ class TestDtNow(object):
         assert dtnow() == datetime(
             2017, 7, 28, 6, 24, 44, tzinfo=utc
         )
+
+
+#: Values that :py:func:`~biweeklybudget.utils.parse_currency` must accept for
+#: the ``en_US``/``USD`` settings used by the test settings module, as
+#: (input, expected Decimal) pairs.
+CURRENCY_ACCEPT_CASES = [
+    # bare integers - github issue #323
+    ('123', Decimal('123')),
+    ('0', Decimal('0')),
+    ('1234', Decimal('1234')),
+    # plain decimals
+    ('123.45', Decimal('123.45')),
+    ('0.01', Decimal('0.01')),
+    # comma thousands separators - github issue #323
+    ('1,234.56', Decimal('1234.56')),
+    ('1,000', Decimal('1000')),
+    ('1,234,567.89', Decimal('1234567.89')),
+    # space thousands separators, including unicode spaces
+    ('1 234.56', Decimal('1234.56')),
+    ('1\u00a0234.56', Decimal('1234.56')),
+    ('1\u202f234.56', Decimal('1234.56')),
+    # currency symbol and ISO code
+    ('$1,234.56', Decimal('1234.56')),
+    ('$ 1,234.56', Decimal('1234.56')),
+    ('1,234.56 $', Decimal('1234.56')),
+    ('USD 1,234.56', Decimal('1234.56')),
+    # explicit signs
+    ('-1,234.56', Decimal('-1234.56')),
+    ('-$1,234.56', Decimal('-1234.56')),
+    ('+123', Decimal('123')),
+    ('-123', Decimal('-123')),
+    # parentheses as negative
+    ('(1,234.56)', Decimal('-1234.56')),
+    ('($1,234.56)', Decimal('-1234.56')),
+    # surrounding whitespace
+    ('  1234.56  ', Decimal('1234.56')),
+    ('\t1,234.56\u00a0', Decimal('1234.56')),
+    # more than 2 decimal places is preserved, not rounded
+    ('1.23456', Decimal('1.23456')),
+    # negative zero is zero, so "cannot be zero" checks still fire
+    ('-0.00', Decimal('0')),
+]
+
+#: Values that :py:func:`~biweeklybudget.utils.parse_currency` must reject.
+CURRENCY_REJECT_CASES = [
+    # not numbers at all
+    'abc',
+    'twelve',
+    '',
+    '   ',
+    '$',
+    '$ ',
+    # invalid grouping; a lenient parser reads these as 1000/1234/123/1234.56
+    # and silently corrupts the amount, which is the whole point of rejecting
+    '10,00',
+    '1,234,',
+    ',123',
+    '1,23,4.56',
+    '1,2345.67',
+    '12,34.5',
+    # space-separated digit runs that are not valid groups
+    '1 2 3',
+    # multiple decimal separators
+    '1.2.3',
+    '1..2',
+    # misplaced signs
+    '5-',
+    '-(5)',
+    '1-2',
+    # things Decimal() would otherwise happily accept
+    '1e5',
+    '1E5',
+    'nan',
+    'NaN',
+    'inf',
+    '-inf',
+    'Infinity',
+    # non-ascii digits
+    '\uff11\uff12\uff13',
+    # non-string input
+    None,
+    123,
+    12.3,
+    Decimal('1.23'),
+    ['1.23'],
+]
+
+
+class TestParseCurrency(object):
+    """
+    Tests for :py:func:`biweeklybudget.utils.parse_currency`; see GitHub issue
+    #323.
+    """
+
+    @pytest.mark.parametrize('value,expected', CURRENCY_ACCEPT_CASES)
+    def test_accepted(self, value, expected):
+        assert parse_currency(value) == expected
+
+    @pytest.mark.parametrize('value,expected', CURRENCY_ACCEPT_CASES)
+    def test_accepted_returns_decimal(self, value, expected):
+        # never a float; cents must survive exactly
+        assert isinstance(parse_currency(value), Decimal)
+
+    @pytest.mark.parametrize('value', CURRENCY_REJECT_CASES)
+    def test_rejected(self, value):
+        with pytest.raises(CurrencyParseError):
+            parse_currency(value)
+
+    def test_currency_parse_error_is_value_error(self):
+        # callers that already catch ValueError keep working
+        assert issubclass(CurrencyParseError, ValueError)
+
+    def test_bare_integer_stays_integral(self):
+        # github issue #323: "123" must not become "123.0"
+        assert str(parse_currency('123')) == '123'
+
+    def test_precision_is_preserved(self):
+        assert str(parse_currency('1.23456')) == '1.23456'
+        assert str(parse_currency('1.50')) == '1.50'
+
+    def test_canonical_form_round_trips(self):
+        for value, _ in CURRENCY_ACCEPT_CASES:
+            parsed = parse_currency(value)
+            assert parse_currency(str(parsed)) == parsed
+
+    def test_no_float_rounding(self):
+        # 0.1 + 0.2 == 0.30000000000000004 in binary floating point
+        assert parse_currency('0.1') + parse_currency('0.2') == Decimal('0.3')
+
+    def test_error_message_includes_value(self):
+        with pytest.raises(CurrencyParseError) as excinfo:
+            parse_currency('1,23,4.56')
+        assert '1,23,4.56' in str(excinfo.value)
+
+
+class TestParseCurrencyLocale(object):
+    """
+    Normalization must be driven by settings, not hard-coded, so that adding a
+    locale is a configuration change rather than a code change.
+    """
+
+    @patch('biweeklybudget.utils.settings.LOCALE_NAME', 'de_DE')
+    @patch('biweeklybudget.utils.settings.CURRENCY_CODE', 'EUR')
+    def test_de_de_accepts_german_formatting(self):
+        assert parse_currency('1.234,56') == Decimal('1234.56')
+        assert parse_currency('1 234,56') == Decimal('1234.56')
+        assert parse_currency('1234,56') == Decimal('1234.56')
+        assert parse_currency('1234') == Decimal('1234')
+
+    @patch('biweeklybudget.utils.settings.LOCALE_NAME', 'de_DE')
+    @patch('biweeklybudget.utils.settings.CURRENCY_CODE', 'EUR')
+    def test_de_de_rejects_us_formatting(self):
+        with pytest.raises(CurrencyParseError):
+            parse_currency('1,234.56')
+
+    @patch('biweeklybudget.utils.settings.LOCALE_NAME', 'de_DE')
+    @patch('biweeklybudget.utils.settings.CURRENCY_CODE', 'EUR')
+    def test_de_de_currency_symbol(self):
+        assert parse_currency('\u20ac1.234,56') == Decimal('1234.56')
+        assert parse_currency('1.234,56 \u20ac') == Decimal('1234.56')

--- a/biweeklybudget/utils.py
+++ b/biweeklybudget/utils.py
@@ -36,6 +36,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 import os
+import string
 import logging
 
 import plaid
@@ -44,11 +45,34 @@ from biweeklybudget import settings
 from datetime import datetime
 import pytz
 from contextlib import contextmanager
-from babel.numbers import format_currency
+from decimal import Decimal
+from babel import Locale
+from babel.numbers import format_currency, get_currency_symbol, parse_decimal
 from plaid import Configuration, ApiClient, Environment
 from plaid.api.plaid_api import PlaidApi
 
 logger = logging.getLogger(__name__)
+
+#: Unicode space characters that users (or their clipboards) may use in place of
+#: a plain ASCII space, most commonly as a digit grouping separator.
+_UNICODE_SPACES = [
+    '\t',
+    '\u00a0',  # NO-BREAK SPACE
+    '\u2007',  # FIGURE SPACE
+    '\u2009',  # THIN SPACE
+    '\u202f',  # NARROW NO-BREAK SPACE
+]
+
+
+class CurrencyParseError(ValueError):
+    """
+    Raised by :py:func:`~.parse_currency` when a string cannot be unambiguously
+    interpreted as a currency amount.
+
+    Subclasses :py:exc:`ValueError` so that callers which already catch
+    ``ValueError`` continue to work.
+    """
+    pass
 
 
 def plaid_client() -> PlaidApi:
@@ -100,6 +124,116 @@ def fmt_currency(amt):
     return format_currency(
         amt, settings.CURRENCY_CODE, locale=settings.LOCALE_NAME
     )
+
+
+def _currency_separators():
+    """
+    Return the digit grouping separator and decimal separator for
+    :py:attr:`~biweeklybudget.settings.LOCALE_NAME`, i.e. ``(',', '.')`` for
+    ``en_US`` and ``('.', ',')`` for ``de_DE``.
+
+    :return: 2-tuple of (grouping separator, decimal separator)
+    :rtype: tuple
+    """
+    symbols = Locale.parse(settings.LOCALE_NAME).number_symbols
+    # Babel >= 2.12 nests number symbols under the numbering system.
+    if 'latn' in symbols:
+        symbols = symbols['latn']
+    return symbols.get('group', ','), symbols.get('decimal', '.')
+
+
+def parse_currency(value):
+    """
+    Parse a user-entered currency string into an exact
+    :py:class:`decimal.Decimal`.
+
+    This is the single authority for turning user input into a number; it is
+    the counterpart to :py:func:`~.fmt_currency`. All formatting conventions
+    come from :py:attr:`~biweeklybudget.settings.LOCALE_NAME` and
+    :py:attr:`~biweeklybudget.settings.CURRENCY_CODE`, so support for another
+    locale is a settings change and not a code change.
+
+    For ``en_US``, all of the following parse to ``Decimal('1234.56')``::
+
+        1234.56   1,234.56   1 234.56   $1,234.56   $ 1,234.56   1,234.56 $
+
+    and all of these parse to ``Decimal('-1234.56')``::
+
+        -1,234.56   -$1,234.56   (1,234.56)   ($1,234.56)
+
+    Bare integers (``123``) are accepted. Input that cannot be interpreted
+    unambiguously - including plausible-looking but invalidly grouped values
+    such as ``10,00`` or ``1,23,4.56`` - raises
+    :py:exc:`~.CurrencyParseError` rather than returning a guess. This matters:
+    lenient parsers read ``10,00`` as ``1000``, which would silently corrupt a
+    financial record.
+
+    :param value: the user-supplied string to parse
+    :type value: str
+    :return: the exact decimal value of ``value``
+    :rtype: decimal.Decimal
+    :raises: CurrencyParseError if ``value`` cannot be interpreted
+    """
+    if not isinstance(value, str):
+        raise CurrencyParseError(
+            'Cannot parse non-string currency value: %r' % value
+        )
+    s = value
+    for space in _UNICODE_SPACES:
+        s = s.replace(space, ' ')
+    s = s.strip()
+    negative = False
+    if s.startswith('(') and s.endswith(')'):
+        negative = True
+        s = s[1:-1].strip()
+    symbol = get_currency_symbol(
+        settings.CURRENCY_CODE, locale=settings.LOCALE_NAME
+    )
+    # Strip the currency symbol, ISO code and sign repeatedly until the string
+    # stops changing. A single pass is not enough: for "-$1,234.56", taking the
+    # sign first leaves "$1,234.56", which the decimal parser rejects.
+    changed = True
+    while changed and s != '':
+        changed = False
+        for token in [symbol, settings.CURRENCY_CODE]:
+            if token == '':
+                continue
+            if s.startswith(token):
+                s = s[len(token):].strip()
+                changed = True
+            elif s.endswith(token):
+                s = s[:-len(token)].strip()
+                changed = True
+        if s.startswith('-') or s.startswith('+'):
+            if s[0] == '-':
+                negative = not negative
+            s = s[1:].strip()
+            changed = True
+    if s == '':
+        raise CurrencyParseError('Invalid currency value: "%s"' % value)
+    group_sep, decimal_sep = _currency_separators()
+    # Rewrite spaces used as grouping separators into the locale's own grouping
+    # separator, rather than simply deleting them, so that the grouping check
+    # below applies to space-separated input too. Deleting them would read
+    # "1 2 3" as 123.
+    s = s.replace(' ', group_sep)
+    # Only digits and the locale's two separators may remain. babel's
+    # parse_decimal() falls back to Decimal(), which happily accepts "1e5",
+    # "nan" and "inf"; none of those are amounts a user meant to type.
+    if not set(s) <= set(string.digits + group_sep + decimal_sep):
+        raise CurrencyParseError('Invalid currency value: "%s"' % value)
+    try:
+        parsed = parse_decimal(s, locale=settings.LOCALE_NAME, strict=True)
+    except Exception as ex:
+        raise CurrencyParseError(
+            'Invalid currency value: "%s" (%s)' % (value, ex)
+        )
+    if not isinstance(parsed, Decimal):
+        # defensive; babel returns Decimal, but never hand back a float
+        parsed = Decimal(str(parsed))
+    if negative:
+        parsed = -parsed
+    return parsed
 
 
 def dtnow():

--- a/biweeklybudget/version.py
+++ b/biweeklybudget/version.py
@@ -35,5 +35,5 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
-VERSION = '1.6.2'
+VERSION = '1.7.0'
 PROJECT_URL = 'https://github.com/jantman/biweeklybudget'

--- a/docs/source/app_usage.rst
+++ b/docs/source/app_usage.rst
@@ -24,6 +24,42 @@ specify currency formatting. The latter, ``CURRENCY_CODE``, must be a valid
 "USD", "EUR", etc.) and can also be set via a ``CURRENCY_CODE`` environment
 variable.
 
+.. _app_usage.currency_input:
+
+Entering Currency Amounts
++++++++++++++++++++++++++
+
+Every currency input in the web UI accepts common formatting; you do not need to
+type a bare, unformatted number. Amounts are interpreted using the same
+``LOCALE_NAME`` and ``CURRENCY_CODE`` settings used to *display* them, by
+:py:func:`biweeklybudget.utils.parse_currency` on the server and its
+counterpart ``parse_currency()`` in ``static/js/custom.js`` in the browser.
+
+For a ``en_US`` / ``USD`` configuration, all of the following are accepted and
+mean the same thing:
+
+.. code-block:: none
+
+    1234.56    1,234.56    1 234.56    $1,234.56    $ 1,234.56    1,234.56 $
+
+Bare integers are accepted; ``123`` does not have to be written as ``123.0``.
+A negative amount may be written with a leading minus sign or wrapped in
+parentheses, so ``-1,234.56``, ``-$1,234.56`` and ``(1,234.56)`` are equivalent.
+Leading and trailing whitespace is ignored.
+
+Input that cannot be interpreted *unambiguously* is rejected with a
+field-level validation error rather than being guessed at. In particular,
+values whose digit grouping is not valid for the locale - such as ``10,00``,
+``1,23,4.56``, ``1,234,`` or ``,123`` - are errors, **not** silently read as
+``1000``, ``1234.56``, ``1234`` and ``123``. This is deliberate: for an
+application that tracks real money, quietly turning a typo into a plausible
+number is worse than refusing it. Likewise ``1.2.3``, ``1 2 3``, ``1e5`` and
+non-numeric text are rejected.
+
+Configuring a different ``LOCALE_NAME`` changes what is accepted as well as
+what is displayed. With ``de_DE``, ``1.234,56`` is 1234.56 and ``1,234.56`` is
+an error.
+
 In addition, the Fuel Log functionality supports customization of the volume,
 distance and fuel economy units via a set of settings (which can also be set
 via environment variables):

--- a/docs/source/jsdoc.custom.rst
+++ b/docs/source/jsdoc.custom.rst
@@ -3,6 +3,15 @@ jsdoc.custom
 
 File: ``biweeklybudget/flaskapp/static/js/custom.js``
 
+.. js:function:: ..................s()
+
+   Return the digit grouping separator and decimal separator for
+   ``LOCALE_NAME``, i.e. ``[',', '.']`` for ``en-US`` and ``['.', ',']`` for
+   ``de-DE``. Determined from ``Intl.NumberFormat`` rather than hard-coded, so
+   that changing the Python ``LOCALE_NAME`` setting is all that is needed to
+   support another locale.
+
+   :returns: **Array** -- 2-element Array of [group separator, decimal separator]
 .. js:function:: ...........y(value)
 
    Format a float as currency. If ``value`` is null, return ``&nbsp;``.
@@ -29,3 +38,25 @@ File: ``biweeklybudget/flaskapp/static/js/custom.js``
    :param d: the date to format
    :type d: **Date**
    :returns: **string** -- YYYY-MM-DD
+.. js:function:: .............y(value)
+
+   Parse a user-entered currency string to a Number, or ``null`` if it cannot
+   be unambiguously interpreted.
+
+   This is the browser counterpart to :js:func:`fmt_currency`, and mirrors
+   ``biweeklybudget.utils.parse_currency()`` on the server; the server remains
+   the authority, and this function exists so that in-browser validation does
+   not reject values the server would accept. See GitHub issue #323.
+
+   For ``en-US``, all of ``1234.56``, ``1,234.56``, ``1 234.56``,
+   ``$1,234.56`` and ``(1,234.56)`` are interpreted, and bare integers such as
+   ``123`` are accepted. Ambiguously grouped values such as ``10,00`` return
+   ``null`` rather than a guess.
+
+   Returns ``null`` and not ``NaN`` deliberately: ``NaN`` comparisons silently
+   evaluate false, which is how ``parseFloat`` used to disable the Save button
+   with no visible reason.
+
+   :param value: the string to parse
+   :type value: **string**
+   :returns: **number|null** -- the numeric value, or null if not interpretable

--- a/specs/20260906-155913-currency-input-normalization/checklists/requirements.md
+++ b/specs/20260906-155913-currency-input-normalization/checklists/requirements.md
@@ -1,0 +1,49 @@
+# Specification Quality Checklist: Currency Value Input Normalization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 flagged two issues, both corrected before this checklist was marked
+  complete:
+  - FR-009 originally read "all currency inputs" with no enumeration, which is not
+    testable. It now names each input, and SC-003 pins coverage to that list.
+  - The original draft described only accepting behavior. User Story 4 and FR-004 were
+    added so that rejection behavior is specified as tightly as acceptance behavior —
+    for a personal-finance application, over-permissive parsing is the more dangerous
+    failure.
+- Deliberate wording choices reviewed against "no implementation details": naming the
+  existing `CURRENCY_SYM` setting in Assumptions and Selenium in Assumptions are
+  statements of the environment the feature lands in, not design decisions, and are kept
+  because a planner needs them. No requirement (FR-xxx) or success criterion (SC-xxx)
+  names a language, framework, module, or function.
+- The precise rejection set referenced by SC-004 and the "separators in impossible
+  positions" edge case is to be fixed during planning; the spec deliberately states the
+  safe default (reject) rather than pre-committing to a parsing algorithm.

--- a/specs/20260906-155913-currency-input-normalization/contracts/form-handler-normalization.md
+++ b/specs/20260906-155913-currency-input-normalization/contracts/form-handler-normalization.md
@@ -1,0 +1,115 @@
+# Contract: `FormHandlerView` currency normalization
+
+The single server-side interception point. Every `/forms/*` endpoint inherits it, so a
+currency field is normalized by declaring its name — not by editing a conversion site.
+
+## Declarations
+
+```python
+class FormHandlerView(MethodView):
+
+    #: Names of form fields holding currency amounts. Values are normalized to
+    #: canonical form before validate() runs; unparseable values become field
+    #: errors and validate() is not called.
+    currency_fields = []
+
+    #: Names of form fields holding non-currency decimal numbers. Same
+    #: normalization, different error wording.
+    decimal_fields = []
+```
+
+Example:
+
+```python
+class TransactionFormHandler(FormHandlerView):
+    currency_fields = ['amount', 'sales_tax']
+```
+
+## Flow in `post()`
+
+```
+data = request JSON or form
+errors = self.normalize_currency(data)          # NEW
+if errors:                                      # NEW
+    return {'success': False, 'errors': errors} # NEW  -> never reaches validate()
+try:                                            # NEW guard
+    res = self.validate(data)
+except Exception:                               # NEW guard
+    log + return {'success': False, 'error_message': ...}
+if res is not None:
+    return {'success': False, 'errors': res}
+try:
+    res = self.submit(data)                     # unchanged
+...
+```
+
+## `normalize_currency(data)`
+
+```python
+def normalize_currency(self, data):
+    """
+    Normalize every currency and decimal field named in ``currency_fields`` and
+    ``decimal_fields`` to canonical string form, in place.
+
+    :param data: submitted form data; modified in place
+    :type data: dict
+    :return: hash of field name to list of error strings; empty if all valid
+    :rtype: dict
+    """
+```
+
+| Rule | Behavior |
+|------|----------|
+| N1 | Fields absent from `data` are skipped, not reported. Handlers share field lists across create/edit shapes. |
+| N2 | Values that are `''` or whitespace-only are **left untouched and not reported**. Each field's existing blank semantics — "means zero", "is required", "means omit" — are unchanged. |
+| N3 | A parseable value is replaced in `data` with `str(parse_currency(value))`, so every downstream `Decimal(data[k])` / `float(data[k])` keeps working with no edit. |
+| N4 | An unparseable value leaves `data` unchanged and appends to `errors[key]`: `Invalid amount: "<raw>"` for `currency_fields`, `Invalid number: "<raw>"` for `decimal_fields`. |
+| N5 | Non-string values (e.g. a JSON number) are passed through untouched — already numeric, nothing to normalize. |
+| N6 | All fields are processed; errors accumulate rather than short-circuiting, so the user sees every bad field at once. |
+| N7 | The returned dict is empty when everything is valid, so `if errors:` is the test. |
+
+## Subclass override — `TransactionFormHandler`
+
+Budget split amounts arrive as a nested `{budget_id: amount}` dict, which a flat name list
+cannot address:
+
+```python
+def normalize_currency(self, data):
+    errors = super().normalize_currency(data)
+    # normalize each value of data['budgets'], accumulating into errors['budgets']
+    return errors
+```
+
+## Non-`FormHandlerView` case — `PayoffSettingsFormHandler`
+
+`credit_payoffs.py:171` is a plain `MethodView` storing amounts in a JSON blob in
+`DBSetting`. It calls `parse_currency` directly in `post()` and writes the canonical string
+into the blob, returning `{'success': False, 'error_message': ...}` for a bad value.
+
+This is normalize-on-write rather than normalize-on-read, and it matters:
+`_payment_settings_dict()` (`credit_payoffs.py:137,142`) calls `Decimal(i['amount'])` while
+**rendering the credit-payoff page**. A bad value stored there breaks an entire page, not
+just a form submission.
+
+## Rewritten validation helpers
+
+| Helper | Before | After |
+|--------|--------|-------|
+| `_validate_decimal` | `Decimal(data[key])` in a bare `try` | `parse_currency(data[key])`; message `Invalid amount: "%s"` |
+| `_validate_float` | `float(data[key])` **plus** `assert data[key].startswith('%s' % x)` — which is why `123` is rejected while `123.0` is accepted | `parse_currency(data[key])`; the round-trip assertion is removed entirely; message `Invalid number: "%s"` |
+| `_validate_int` | `int()` plus `assert data[key] == '%d' % x` | **unchanged** — the assertion is correct for integers |
+
+Removing the `startswith` assertion is safe: it existed to catch `float()` accepting things
+that are not really the given number (`1e5`, `nan`, `inf`, padded strings), and
+`parse_currency` rejects all of those by construction.
+
+## Why `validate()` gets a `try`/`except`
+
+`submit()` has been guarded since the beginning; `validate()` never was. That asymmetry
+*is* the reported 500: `TransactionFormHandler.validate()` calls `Decimal(data['amount'])`
+on line 280, and `Decimal('1,234.56')` raises `InvalidOperation` straight out to Flask.
+Six other validators have the same shape with unguarded `float()`.
+
+Normalization alone prevents today's known crashes; the guard is what makes FR-005 —
+"never an unhandled server error" — a property of the code rather than of the current call
+list. Both are implemented.

--- a/specs/20260906-155913-currency-input-normalization/contracts/parse_currency-js.md
+++ b/specs/20260906-155913-currency-input-normalization/contracts/parse_currency-js.md
@@ -1,0 +1,65 @@
+# Contract: `parse_currency(value)` in `static/js/custom.js`
+
+The browser mirror of `biweeklybudget.utils.parse_currency`. Sibling of the existing
+`fmt_currency(value)` in the same file.
+
+## Signature
+
+```javascript
+/**
+ * Parse a user-entered currency string to a Number, or null if it cannot be
+ * interpreted. Mirrors biweeklybudget.utils.parse_currency() on the server.
+ *
+ * @param {string} value - the string to parse
+ * @returns {(number|null)} the numeric value, or null if not interpretable
+ */
+function parse_currency(value)
+```
+
+## Guarantees
+
+| # | Guarantee |
+|---|-----------|
+| J1 | Returns `null` — not `NaN`, not `0` — for anything it cannot interpret. Every call site tests for `null` explicitly. |
+| J2 | Accepts every form the server accepts, and rejects every form the server rejects, for the locale in force. The server remains the authority; the client must never be *stricter*, or it would block a submission the server would have accepted. |
+| J3 | Separators come from `Intl.NumberFormat(LOCALE_NAME)` and the symbol from the `CURRENCY_SYMBOL` global, both already set by `base.html`. Nothing is hard-coded. |
+| J4 | Returns a JavaScript `Number`. Precision loss is acceptable here and only here: this value feeds on-screen validation feedback, never storage. The server re-parses to an exact `Decimal`. |
+
+## Why `null` and not `NaN`
+
+`parseFloat` returns `NaN`, and `NaN`-based comparisons silently evaluate false, which is
+how the existing split-transaction check can disable Save with no visible reason. An
+explicit `null` forces each call site to decide what an unparseable field means.
+
+## Placement
+
+`custom.js`, because:
+
+- It already holds `fmt_currency`, the formatting counterpart — the pair stays together.
+- `base.html` already loads it on every page, so no new `<script>` tag is needed.
+- `LOCALE_NAME`, `CURRENCY_CODE`, and `CURRENCY_SYMBOL` are already in scope there.
+- `docs/make_jsdoc.py` auto-discovers files in the JS directory, so `jsdoc.custom.rst`
+  regenerates with no manual doc wiring.
+
+## Call sites replaced
+
+All four `parseFloat` uses in `biweeklybudget/flaskapp/static/js/transactions_modal.js`:
+
+| Location | Current | Change |
+|----------|---------|--------|
+| `validateTransModalSplits()` line 265 | `parseFloat($('#trans_frm_budget_amount_' + rownum).val())` | `parse_currency(...)`; a `null` allocation makes the form report an invalid amount rather than summing `NaN` |
+| `validateTransModalSplits()` line 268 | `parseFloat($('#trans_frm_amount').val())` | `parse_currency(...)`; a `null` transaction amount suppresses the mismatch message instead of showing `NaN` — the server will produce the real field error |
+| `transModalSplitBudgetChanged()` line 339 | `parseFloat($('#trans_frm_amount').val())` | `parse_currency(...)`; skip the remainder auto-fill when `null` |
+| `transModalSplitBudgetChanged()` line 343 | `parseFloat($('#trans_frm_budget_amount_' + rownum).val())` | `parse_currency(...)`; treat `null` as "not yet a number" and skip |
+
+**Why this matters**: `parseFloat('1,234.56')` is `1`. Today a split transaction for
+`1,234.56` reports "Sum of budget allocations (1234.5600) must equal transaction amount
+(1.0000)" and disables Save, so the user cannot even reach the server. This is User
+Story 5.
+
+## Verification
+
+This repository has no JavaScript unit-test harness, and adding one is out of scope. The
+contract is verified through Selenium acceptance tests that drive the real Transaction
+modal — which is the stronger check, since it exercises the actual page wiring rather
+than the function in isolation.

--- a/specs/20260906-155913-currency-input-normalization/contracts/parse_currency-python.md
+++ b/specs/20260906-155913-currency-input-normalization/contracts/parse_currency-python.md
@@ -1,0 +1,101 @@
+# Contract: `biweeklybudget.utils.parse_currency`
+
+The single server-side authority for turning a user-supplied currency string into a
+number. Sibling of the existing `biweeklybudget.utils.fmt_currency`.
+
+## Signature
+
+```python
+def parse_currency(value):
+    """
+    :param value: the user-supplied string to parse
+    :type value: str
+    :return: the exact decimal value of ``value``
+    :rtype: decimal.Decimal
+    :raises: CurrencyParseError if ``value`` cannot be unambiguously interpreted
+    """
+```
+
+```python
+class CurrencyParseError(ValueError):
+    """Raised when a string cannot be interpreted as a currency amount."""
+```
+
+`CurrencyParseError` subclasses `ValueError` so that callers which already catch
+`ValueError` (or bare `Exception`) keep working.
+
+## Guarantees
+
+| # | Guarantee |
+|---|-----------|
+| C1 | Returns `decimal.Decimal`, never `float`. No binary floating point is used at any point. (FR-007) |
+| C2 | Raises `CurrencyParseError` for every input it cannot unambiguously interpret. It never returns a guessed value, a partial parse, `0`, or `None`. (FR-004) |
+| C3 | Locale behavior comes from `settings.LOCALE_NAME` and `settings.CURRENCY_CODE` at call time. No separator or symbol is hard-coded. (FR-008) |
+| C4 | Idempotent through its own output: `parse_currency(str(parse_currency(x))) == parse_currency(x)` for all accepted `x`. |
+| C5 | Preserves the precision given. `1.23456` → `Decimal('1.23456')`; `123` → `Decimal('123')`. No rounding, no padding to 2 places. |
+| C6 | Total: for any input, it either returns a `Decimal` or raises `CurrencyParseError`. It raises no other exception type, including for `None`, numbers, or other non-string input. |
+
+## Algorithm
+
+Implements research R-4. Order matters.
+
+1. Reject non-`str` input with `CurrencyParseError`.
+2. Replace Unicode space variants (`U+00A0`, `U+2007`, `U+2009`, `U+202F`, tab) with ASCII
+   space; strip.
+3. If wrapped in `(` … `)`, strip them and record a negation.
+4. **Loop until the string stops changing**: strip a leading/trailing currency symbol, a
+   leading/trailing ISO currency code, or a leading `+`/`-` sign (a `-` toggles the
+   negation), stripping whitespace after each removal.
+   *The loop is required*: a single pass fails `-$1,234.56`, because taking the sign first
+   leaves `$1,234.56`, which Babel rejects.
+5. If the string is now empty, raise `CurrencyParseError`.
+6. Replace remaining internal ASCII spaces with the locale's group separator.
+   *Not* "delete all spaces" — that would read `1 2 3` as `123`. Rewriting to the group
+   separator lets step 7's grouping validation reject it.
+7. `babel.numbers.parse_decimal(s, locale=settings.LOCALE_NAME, strict=True)`.
+   `strict=True` is **required**: without it Babel silently reads `10,00` as `1000` and
+   `1,234,` as `1234`.
+8. Apply the recorded negation; return.
+
+Any exception from Babel is re-raised as `CurrencyParseError` with the original value in
+the message.
+
+## Behavior matrix (locale `en_US`, currency `USD`)
+
+All rows verified against a working prototype during Phase 0.
+
+| Input | Result | | Input | Result |
+|-------|--------|-|-------|--------|
+| `'123'` | `Decimal('123')` | | `'1 2 3'` | raises |
+| `'123.45'` | `Decimal('123.45')` | | `'1,23,4.56'` | raises |
+| `'1,234.56'` | `Decimal('1234.56')` | | `'10,00'` | raises |
+| `'1 234.56'` | `Decimal('1234.56')` | | `'1,234,'` | raises |
+| `'1 234.56'` | `Decimal('1234.56')` | | `',123'` | raises |
+| `'$1,234.56'` | `Decimal('1234.56')` | | `'1.2.3'` | raises |
+| `'$ 1,234.56'` | `Decimal('1234.56')` | | `'abc'` | raises |
+| `'1,234.56 $'` | `Decimal('1234.56')` | | `''` | raises |
+| `'-1,234.56'` | `Decimal('-1234.56')` | | `'   '` | raises |
+| `'-$1,234.56'` | `Decimal('-1234.56')` | | `'$'` | raises |
+| `'(1,234.56)'` | `Decimal('-1234.56')` | | `'5-'` | raises |
+| `'($1,234.56)'` | `Decimal('-1234.56')` | | `'-(5)'` | raises |
+| `'+123'` | `Decimal('123')` | | `None` | raises |
+| `'  1234.56  '` | `Decimal('1234.56')` | | `123` (int) | raises |
+| `'1.23456'` | `Decimal('1.23456')` | | `'1e5'` | raises |
+| `'0'` | `Decimal('0')` | | `'nan'` | raises |
+| `'-0.00'` | `Decimal('0.00')` | | `'inf'` | raises |
+
+`-0.00` yielding `Decimal('0.00')` is deliberate: it compares equal to `Decimal('0')`, so
+existing "amount cannot be zero" checks keep firing.
+
+## Locale independence
+
+With `LOCALE_NAME='de_DE'`, `CURRENCY_CODE='EUR'` (verified in prototype):
+
+| Input | Result |
+|-------|--------|
+| `'1.234,56'` | `Decimal('1234.56')` |
+| `'1 234,56'` | `Decimal('1234.56')` |
+| `'1234,56'` | `Decimal('1234.56')` |
+| `'1,234.56'` | raises |
+
+No call site changes. This is the evidence for SC-006.

--- a/specs/20260906-155913-currency-input-normalization/data-model.md
+++ b/specs/20260906-155913-currency-input-normalization/data-model.md
@@ -1,0 +1,115 @@
+# Phase 1 Data Model: Currency Value Input Normalization
+
+**Feature**: `specs/20260906-155913-currency-input-normalization`
+
+This feature introduces **no database entities and no schema change**. `biweeklybudget/models/`
+is untouched, so no Alembic migration is required (constitution III). What follows are the
+in-memory value shapes the feature introduces, and the authoritative inventory of the
+fields it governs.
+
+## Value shapes
+
+### Raw currency input
+
+The string as submitted, straight from `request.get_json()` or `request.form`.
+
+| Property | Value |
+|----------|-------|
+| Type | `str` (never trusted to be numeric) |
+| Source | Browser form field, or any HTTP client posting to a `/forms/*` endpoint |
+| Lifetime | Replaced in-place inside `data` by the canonical form before `validate()` runs |
+| Blank | `''` or whitespace-only is **not** an error at the normalization layer; it is passed through untouched so each field's existing blank semantics still apply |
+
+### Canonical currency value
+
+| Property | Value |
+|----------|-------|
+| Type | `decimal.Decimal` (exact; never `float`) |
+| String form | `str(Decimal)` — plain digits, optional `-`, optional `.` fraction. No grouping separators, no currency symbol, no whitespace. |
+| Precision | Whatever the input carried. Normalization neither rounds nor pads: `1.23456` stays `1.23456`, `123` stays `123`. Rounding, where it happens, remains the responsibility of the model column, exactly as today. |
+| Guarantee | `parse_currency(str(parse_currency(x))) == parse_currency(x)` for every accepted `x` |
+
+Storing the canonical **string** back into `data` (rather than the `Decimal`) is what lets
+every existing `Decimal(data['amount'])` and `float(data['amount'])` call downstream keep
+working with no edit.
+
+### Parse failure
+
+| Property | Value |
+|----------|-------|
+| Type | `CurrencyParseError`, a subclass of `ValueError` |
+| Raised for | Unparseable text, ambiguous grouping, empty-after-cleaning input, non-`str` input |
+| Never | Returns a partial parse, a guessed value, `0`, or `None` in the Python API (FR-004) |
+| Browser counterpart | JS `parse_currency()` returns `null` — JS has no exception idiom here, and every call site is a truthiness check |
+
+### Locale conventions
+
+Not a stored object — a set of lookups performed per call, so a settings change takes
+effect with no code change (FR-008, SC-006).
+
+| Convention | Server source | Browser source |
+|------------|---------------|----------------|
+| Decimal separator | `babel` CLDR data for `settings.LOCALE_NAME` | `Intl.NumberFormat(LOCALE_NAME).formatToParts()` |
+| Group separator | `Locale.parse(LOCALE_NAME).number_symbols['latn']['group']` | `Intl.NumberFormat(LOCALE_NAME).formatToParts()` |
+| Currency symbol | `get_currency_symbol(settings.CURRENCY_CODE, settings.LOCALE_NAME)` | `CURRENCY_SYMBOL` global from `base.html` |
+| Grouping validity | `parse_decimal(..., strict=True)` | Mirrored check in `custom.js` |
+
+## Field inventory
+
+The authoritative expansion of **FR-009**. Each row becomes one `currency_fields` /
+`decimal_fields` entry, and each form gets acceptance coverage.
+
+### Currency fields (`currency_fields`)
+
+| Form / page | Handler | Field name(s) | Notes |
+|-------------|---------|---------------|-------|
+| Transaction modal | `TransactionFormHandler` (`transactions.py:256`) | `amount`, `sales_tax` | Site of the reported 500 |
+| Transaction modal — budget splits | `TransactionFormHandler` | values of the `budgets` dict | Nested; needs the hook override |
+| Scheduled Transaction modal | `SchedTransFormHandler` (`scheduled.py:211`) | `amount`, `sales_tax` | |
+| Pay period → convert scheduled txn | `SchedToTransFormHandler` (`payperiods.py:231`) | `amount`, `sales_tax` | |
+| Pay period → skip scheduled txn | `SkipSchedTransFormHandler` (`payperiods.py:302`) | `amount` | |
+| Budget modal | `BudgetFormHandler` (`budgets.py:168`) | `starting_balance`, `current_balance` | Blank is meaningful — one or the other is required depending on `is_periodic` |
+| Budget transfer modal | `BudgetTxfrFormHandler` (`budgets.py:243`) | `amount` | |
+| Account modal | `AccountFormHandler` (`accounts.py:165`) | `credit_limit`, `apr`, `prime_rate_margin` | All three optional/blank-allowed. `apr` and `prime_rate_margin` are rates, not money, but are entered in the same shape and validated by `_validate_decimal` today; the existing ">1 means percent, divide by 100" logic in `submit()` is unchanged |
+| Account transfer modal | `AccountTxfrFormHandler` (`accounts.py:312`) | `amount` | |
+| Fuel Log modal | `FuelLogFormHandler` (`fuel.py:263`) | `cost_per_gallon`, `total_cost` | |
+| BoM Item modal | `BoMItemFormHandler` (`projects.py:400`) | `unit_cost` | |
+| Credit payoff — OFX interest | `AccountOfxFormHandler` (`credit_payoffs.py:243`) | `interest_amt` | `validate()` is currently a bare `pass` |
+| Credit payoff — settings | `PayoffSettingsFormHandler` (`credit_payoffs.py:171`) | `amount` within each `increases[]` / `onetimes[]` entry | Plain `MethodView`, not a `FormHandlerView`. Normalized before the JSON blob is stored, because `_payment_settings_dict()` re-parses it while *rendering the page* — a bad stored value breaks the whole credit-payoff page |
+
+### Non-currency decimal fields (`decimal_fields`)
+
+Same parser, "number" rather than "amount" error wording (research R-8).
+
+| Form | Handler | Field name(s) | Why in scope |
+|------|---------|---------------|--------------|
+| Fuel Log modal | `FuelLogFormHandler` (`fuel.py:263`) | `gallons`, `reported_mpg` | Validated by the same `_validate_float` whose assertion rejects bare integers; entering `10` gallons fails today |
+
+### Explicitly out of scope
+
+- **Integer fields** — `quantity`, `odometer_miles`, `reported_miles`, `level_before`,
+  `level_after`, and all record IDs. `_validate_int`'s round-trip assertion is correct for
+  integers and stays as-is.
+- **Display formatting** — `fmt_currency` on both sides is already correct and unchanged.
+- **Read paths** — OFX/Plaid import, reconciliation, and payoff arithmetic consume values
+  that are already `Decimal`s from the database; they never see a user-typed string.
+
+## Validation rules
+
+Derived from FR-003 (accept) and FR-004 (reject); the full verified matrix is in
+[research.md](./research.md) R-4.
+
+**Accepted** (locale `en_US`): bare integers; decimals; `,` grouping; space grouping
+(including NBSP and other Unicode spaces); leading or trailing currency symbol or ISO
+code, with or without an intervening space; leading `+` or `-`; parentheses for negative;
+any combination of the above; surrounding whitespace.
+
+**Rejected**: anything non-numeric; multiple decimal separators; invalid grouping
+(`10,00`, `1,23,4.56`, `1,234,`, `,123`); space-separated digit runs that are not valid
+groups (`1 2 3`); trailing signs (`5-`); empty or symbol-only input; non-string input.
+
+**Invariants**:
+- Rejection is always distinguishable from success — never a guessed value (FR-004).
+- Accepted input is never rejected by a later step: normalization runs *before*
+  `validate()`, and produces a string that every downstream `Decimal()`/`float()` accepts.
+- Nothing valid today becomes invalid (FR-010).

--- a/specs/20260906-155913-currency-input-normalization/plan.md
+++ b/specs/20260906-155913-currency-input-normalization/plan.md
@@ -172,6 +172,10 @@ docs updated.
 - **M5 — Completion.** Docs, regenerated jsdoc, version bump, `CHANGES.rst`, full
   `py314` + `acceptance` + `docs` + `jsdoc` + `migrations` suites green, PR opened.
 
+**Status: all five milestones complete.** See the Completion Status section of
+[tasks.md](./tasks.md) for suite results and for the three parser defects and one
+test-isolation bug found during implementation.
+
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |

--- a/specs/20260906-155913-currency-input-normalization/plan.md
+++ b/specs/20260906-155913-currency-input-normalization/plan.md
@@ -1,0 +1,180 @@
+# Implementation Plan: Currency Value Input Normalization
+
+**Branch**: `robot-army/issue-323-currency-value-input-normalization` | **Date**: 2026-09-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/20260906-155913-currency-input-normalization/spec.md`
+
+## Summary
+
+Every currency string a user types is converted to a number in one of ~30 scattered
+`Decimal(data['x'])` / `float(data['x'])` calls, and two of those conversions are
+defective: unguarded conversion inside `validate()` turns `1,234.56` into a 500, and a
+`startswith` round-trip assertion in `_validate_float` rejects `123`.
+
+The fix collapses all of that into **two functions and one interception point**:
+
+- `biweeklybudget.utils.parse_currency()` — the single server-side authority, a pre-clean
+  step wrapping `babel.numbers.parse_decimal(..., strict=True)` against
+  `settings.LOCALE_NAME` / `settings.CURRENCY_CODE`. Babel is already a dependency and
+  already provides this module's `fmt_currency()` counterpart.
+- `parse_currency()` in `static/js/custom.js` — the browser mirror, sibling of the
+  existing `fmt_currency()`, replacing the four `parseFloat()` calls in
+  `transactions_modal.js`.
+- `FormHandlerView.post()` — normalizes every field named in a per-handler
+  `currency_fields` declaration into canonical form *before* `validate()` runs, so all
+  existing downstream conversions keep working untouched.
+
+`validate()` also gets the same `try`/`except` guard `submit()` already has, so no
+conversion anywhere can produce a 500 again.
+
+Locale conventions are read from settings on both sides and never hard-coded, so a second
+locale is a configuration change (verified: `de_DE` parses `1.234,56` correctly through
+the same code path).
+
+## Technical Context
+
+**Language/Version**: Python 3.14; ES5-style browser JavaScript (jQuery 1.x / Bootstrap 3 era)
+
+**Primary Dependencies**: Flask, SQLAlchemy, Babel 2.18.0 (already present — supplies both
+`format_currency` and `parse_decimal`). **No new dependencies.**
+
+**Storage**: MySQL/MariaDB. **No schema change** — this feature does not touch
+`biweeklybudget/models/`.
+
+**Testing**: pytest (unit, `tox -e py314`); pytest + Selenium (acceptance,
+`tox -e acceptance`); pycodestyle + pyflakes enforced in the unit env
+
+**Target Platform**: Localhost Flask web application, single trusted operator
+
+**Project Type**: Web application — Flask backend with server-rendered Jinja2 templates and
+jQuery/DataTables frontend, in a single Python package
+
+**Performance Goals**: Not applicable. Parsing runs once per submitted form field; no
+measurable budget.
+
+**Constraints**: Amounts must remain exact `Decimal`s end to end — no `float` may enter a
+value path (financial correctness). Parsing must reject ambiguous input rather than guess.
+No new frontend stack (constitution: jQuery/Bootstrap 3/DataTables only).
+
+**Scale/Scope**: 18 currency inputs across 13 form handlers, 2 new functions, 1 new
+`try`/`except`, ~4 `parseFloat` replacements, 1 JSON-settings handler.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-evaluated after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **I. Spec-Driven Change** (NON-NEGOTIABLE) | ✅ PASS | Spec written and committed before planning; work is on feature branch `robot-army/issue-323-currency-value-input-normalization`; plan precedes implementation; decomposed into milestones in `tasks.md`. Single feature, worked alone. |
+| **II. The Test Gate** (NON-NEGOTIABLE) | ✅ PASS (gate to enforce at completion) | Plan mandates full `py314` **and** `acceptance` suites run to completion and pass before the feature is declared done. New code is covered by real unit tests over the accept/reject matrix plus browser tests (FR-011). pycodestyle/pyflakes clean is enforced by the `py314` env. No suite may be narrowed; a timeout must be raised, not worked around. |
+| **III. Reversible Migrations** | ✅ N/A | No change to `biweeklybudget/models/`, therefore no migration. `tox -e migrations` must still pass unchanged, and is included in the verification milestone as a regression check. |
+| **IV. Documentation Is Part Of The Change** | ✅ PASS | `docs/source/app_usage.rst` gains an "accepted input formats" subsection alongside the existing localization docs; `CLAUDE.md` needs no change (no new commands or env vars); `biweeklybudget.utils.rst` regenerates under `tox -e docs`; `jsdoc.custom.rst` regenerates under `tox -e jsdoc`. Both doc envs must build clean. |
+| **V. Escalate Instead Of Guessing** | ✅ PASS | The one genuinely ambiguous decision — what to do with malformed grouping like `10,00` — is resolved explicitly and conservatively (reject; see research R-3/R-4) rather than guessed at, and the rejection set is written into the spec and pinned by tests. No side quests. |
+| **VI. Versioned, Changelogged Releases** | ✅ PASS | `version.py` 1.6.2 → **1.7.0** (added accepted behavior, backward compatible); matching `CHANGES.rst` entry. No new Python or JS files are created, so no new copyright headers are needed — both new functions land in existing files that already carry the AGPL header. |
+| **Tech constraints — stack** | ✅ PASS | No new frontend stack; the JS function is plain ES5 in an existing file, using `Intl` which the app already relies on for `fmt_currency`. |
+| **Tech constraints — license** | ✅ PASS | No dependency added. Babel is already in `requirements.txt`. |
+| **Tech constraints — financial correctness** | ✅ PASS | This change is squarely in "how amounts are computed" territory, so it ships with tests that pin exact expected `Decimal` values, including a no-float-rounding assertion. Parsing returns `Decimal`, never `float`. |
+| **Tech constraints — security posture** | ✅ PASS | Unchanged. No new exposure; parsing is total and raises rather than executing anything. |
+| **Tech constraints — test data safety** | ✅ PASS | Acceptance tests use the existing `refreshdb`/`testflask` fixtures and test settings; no real database is touched. |
+| **Workflow — milestone approval** | ⚠️ DEVIATION | The constitution requires human approval at each milestone boundary. This session was dispatched to run the lifecycle through to a pull request without interactive approval. Recorded in Complexity Tracking below; the PR is the review gate. |
+
+**Post-Phase-1 re-evaluation**: no gate changed status. The design added no dependency, no
+model change, no new file, and no new architectural layer — it removes call sites rather
+than adding them. The single deviation is procedural (unattended execution), not
+technical.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260906-155913-currency-input-normalization/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output — root causes, library choice, parse rules
+├── data-model.md        # Phase 1 output — value/error shapes and the field inventory
+├── quickstart.md        # Phase 1 output — how to run and verify
+├── contracts/
+│   ├── parse_currency-python.md   # Server-side function contract
+│   ├── parse_currency-js.md       # Browser function contract
+│   └── form-handler-normalization.md  # FormHandlerView interception contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+biweeklybudget/
+├── utils.py                              # MODIFIED: + parse_currency(), + CurrencyParseError
+├── version.py                            # MODIFIED: 1.6.2 -> 1.7.0
+├── flaskapp/
+│   ├── static/js/
+│   │   ├── custom.js                     # MODIFIED: + parse_currency() (mirrors utils.py)
+│   │   └── transactions_modal.js         # MODIFIED: 4x parseFloat -> parse_currency
+│   └── views/
+│       ├── formhandlerview.py            # MODIFIED: currency_fields, decimal_fields,
+│       │                                 #   normalization in post(), guarded validate(),
+│       │                                 #   _validate_decimal/_validate_float rewritten
+│       ├── transactions.py               # MODIFIED: declare fields + budgets dict override
+│       ├── scheduled.py                  # MODIFIED: declare fields
+│       ├── payperiods.py                 # MODIFIED: declare fields (2 handlers)
+│       ├── budgets.py                    # MODIFIED: declare fields (2 handlers)
+│       ├── accounts.py                   # MODIFIED: declare fields (2 handlers)
+│       ├── fuel.py                       # MODIFIED: declare currency + decimal fields
+│       ├── projects.py                   # MODIFIED: declare fields
+│       └── credit_payoffs.py             # MODIFIED: declare fields; normalize JSON settings
+└── tests/
+    ├── unit/
+    │   ├── test_utils.py                 # MODIFIED: + parse_currency test matrix
+    │   └── flaskapp/views/
+    │       └── test_formhandlerview.py   # NEW or MODIFIED: normalization hook tests
+    └── acceptance/flaskapp/views/
+        ├── test_transactions.py          # MODIFIED: + normalization browser tests
+        ├── test_budgets.py               # MODIFIED: + normalization browser tests
+        ├── test_accounts.py              # MODIFIED: + normalization browser tests
+        ├── test_fuel.py                  # MODIFIED: + normalization browser tests
+        ├── test_projects.py              # MODIFIED: + normalization browser tests
+        ├── test_scheduled.py             # MODIFIED: + normalization browser tests
+        ├── test_payperiods.py            # MODIFIED: + normalization browser tests
+        └── test_credit_payoffs.py        # MODIFIED: + normalization browser tests
+
+docs/source/app_usage.rst                 # MODIFIED: accepted input formats
+docs/source/jsdoc.custom.rst              # REGENERATED by tox -e jsdoc
+CHANGES.rst                               # MODIFIED: 1.7.0 entry
+```
+
+**Structure Decision**: The existing single-package Flask layout is used as-is. No new
+files are created: the server function joins its formatting counterpart in
+`biweeklybudget/utils.py`, and the browser function joins *its* counterpart in
+`static/js/custom.js`. This is deliberate — `custom.js` is already loaded on every page by
+`base.html` and already receives the `LOCALE_NAME` / `CURRENCY_CODE` / `CURRENCY_SYMBOL`
+globals, so no new `<script>` tag or template change is needed, and `docs/make_jsdoc.py`
+auto-discovers the file.
+
+## Implementation Milestones
+
+Milestone boundaries are where the constitution requires the suites to be green and the
+docs updated.
+
+- **M1 — Parsing core.** `parse_currency()` + `CurrencyParseError` in `utils.py`, with the
+  full unit-test matrix (accept, reject, locale, exactness). Independently verifiable with
+  `tox -e py314`.
+- **M2 — Server-side wiring.** `FormHandlerView` normalization hook, guarded `validate()`,
+  rewritten `_validate_decimal`/`_validate_float`, `currency_fields` declared on all 13
+  handlers, `TransactionFormHandler` budgets override, `PayoffSettingsFormHandler` JSON
+  normalization. Delivers Stories 1, 2, 3 and 4 end to end for any client.
+- **M3 — Browser wiring.** `parse_currency()` in `custom.js`; `transactions_modal.js`
+  switched off `parseFloat`. Delivers Story 5.
+- **M4 — Browser tests.** Acceptance coverage across the FR-009 inventory (FR-011, SC-003,
+  SC-004).
+- **M5 — Completion.** Docs, regenerated jsdoc, version bump, `CHANGES.rst`, full
+  `py314` + `acceptance` + `docs` + `jsdoc` + `migrations` suites green, PR opened.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| Constitution §Development Workflow step 3 — "Obtain human approval of the plan before implementing, and again at each milestone boundary" is not obtained interactively | This session was dispatched to run `/speckit-specify → /speckit-plan → /speckit-tasks → /speckit-implement` through to an opened pull request without a human in the loop. Stopping at the first milestone boundary would deliver nothing. | Not applicable — the deviation is imposed by how the work was dispatched, not chosen for convenience. It is mitigated rather than removed: every artifact (spec, plan, research, tasks) is committed for review, the full test gate is still enforced before completion, and the pull request stands as the human approval gate before anything merges. |
+| `FormHandlerView` gains a declarative `currency_fields` / `decimal_fields` class attribute — a small amount of framework machinery | Without it, normalization must be repeated at ~30 conversion sites across `validate()` and `submit()` in 13 handlers. The issue explicitly asks for normalization "in as few places as possible using specific reused functions/methods", and SC-005 requires a reviewer be able to enumerate every conversion from one function's callers. | Per-call-site normalization was rejected: 30 edits, 30 chances to miss one, and no way to audit completeness. A full form-object/WTForms layer was also rejected as far more machinery than the issue warrants. |

--- a/specs/20260906-155913-currency-input-normalization/quickstart.md
+++ b/specs/20260906-155913-currency-input-normalization/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Validating Currency Value Input Normalization
+
+How to run and verify this feature. Details of *what* the code does are in
+[contracts/](./contracts/); this file is the run guide.
+
+## Prerequisites
+
+A MySQL/MariaDB instance is required for the unit and acceptance suites.
+
+```bash
+docker run -d --name budgettest -p 13306:3306 \
+  --env MYSQL_ROOT_PASSWORD=dbroot \
+  --env MYSQL_ROOT_HOST='%' \
+  mariadb:10.4.7
+
+export DB_CONNSTRING='mysql+pymysql://root:dbroot@127.0.0.1:13306/budgettest?charset=utf8mb4'
+export SETTINGS_MODULE='biweeklybudget.tests.fixtures.test_settings'
+export MYSQL_HOST=127.0.0.1
+export MYSQL_PORT=13306
+export MYSQL_USER=root
+export MYSQL_PASS=dbroot
+export MYSQL_DBNAME=budgettest
+export MYSQL_DBNAME_LEFT=alembicLeft
+export MYSQL_DBNAME_RIGHT=alembicRight
+
+source venv/bin/activate
+python dev/setup_test_db.py
+```
+
+Acceptance tests additionally need Chrome and chromedriver on `PATH`.
+
+Cleanup: `docker stop budgettest && docker rm budgettest`
+
+## Running the suites
+
+Always redirect test output to a file rather than piping to `tail`/`grep`, so the full
+output stays available (per `CLAUDE.md`).
+
+```bash
+source venv/bin/activate
+
+# Unit tests, pycodestyle and pyflakes. Covers the parser and the normalization hook.
+tox -e py314 > /tmp/py314.txt 2>&1
+
+# Browser tests. Covers every form in the FR-009 inventory.
+tox -e acceptance > /tmp/acceptance.txt 2>&1
+
+# Regression checks — this feature changes no models and no packaging,
+# so these must pass exactly as before.
+tox -e migrations > /tmp/migrations.txt 2>&1
+
+# Documentation must build clean (constitution IV).
+tox -e docs  > /tmp/docs.txt 2>&1
+tox -e jsdoc > /tmp/jsdoc.txt 2>&1   # regenerates docs/source/jsdoc.custom.rst
+```
+
+Narrower runs while iterating:
+
+```bash
+pytest biweeklybudget/tests/unit/test_utils.py -k parse_currency
+tox -e acceptance -- -k "TestTransModalCurrencyNormalization" > /tmp/one.txt 2>&1
+```
+
+A suite that times out has **not** passed. Raise both the `pytest.ini` timeout and the
+invoking tool's timeout and re-run to completion — do not narrow the run (constitution II).
+
+## Manual verification in a browser
+
+```bash
+export FLASK_APP=biweeklybudget.flaskapp.app:app
+flask rundev
+```
+
+Then, at <http://127.0.0.1:5000/transactions> → **Add Transaction**:
+
+| # | Do this | Expect | Covers |
+|---|---------|--------|--------|
+| 1 | Amount `1,234.56`, a description, an account, a budget → Save | Saved as `$1,234.56`. **No 500 page.** | Story 1, SC-001 |
+| 2 | Amount `123` → Save | Saved as `$123.00`. No "Invalid float value" error. | Story 2, SC-002 |
+| 3 | Amount `$1,234.56`, then ` 1 234.56 `, then `(1,234.56)` | `1234.56`, `1234.56`, `-1234.56` | Story 3 |
+| 4 | Amount `abc` → Save | Red field-level error on Amount reading `Invalid amount: "abc"`. No 500. No row created. | Story 4, SC-004 |
+| 5 | Amount `1.2.3` → Save | Same as #4. | Story 4 |
+| 6 | Check **Budget Split?**, Amount `1,234.56`, one allocation `1,234.56` | No "sum of budget allocations" error; Save stays enabled; saves. | Story 5 |
+
+Then spot-check the other forms — Fuel Log (`/fuel`, Total Cost `123`), BoM Item
+(`/projects`, Unit Cost `1,000`), Budget transfer, Account credit limit, Credit payoff
+settings — each with a comma-separated value.
+
+## What "done" looks like
+
+- `tox -e py314` and `tox -e acceptance` both run to completion with zero failures.
+- `tox -e migrations`, `tox -e docs`, `tox -e jsdoc` unchanged and green.
+- Every row of the manual table above behaves as stated.
+- `grep -rn "currency_fields\|decimal_fields" biweeklybudget/flaskapp/views/` enumerates
+  every server-side currency field (SC-005); `grep -rn "parseFloat" biweeklybudget/flaskapp/static/js/`
+  returns nothing in `transactions_modal.js`.
+- `version.py` is `1.7.0` with a matching `CHANGES.rst` entry.

--- a/specs/20260906-155913-currency-input-normalization/research.md
+++ b/specs/20260906-155913-currency-input-normalization/research.md
@@ -1,0 +1,289 @@
+# Phase 0 Research: Currency Value Input Normalization
+
+**Feature**: `specs/20260906-155913-currency-input-normalization`
+**Date**: 2026-09-06
+
+## R-1: Root cause of the reported 500 Internal Server Error
+
+**Finding**: `FormHandlerView.post()`
+(`biweeklybudget/flaskapp/views/formhandlerview.py:49`) wraps `self.submit(data)` in a
+`try`/`except` that turns any exception into a JSON `error_message`, but calls
+`self.validate(data)` **unguarded**. `TransactionFormHandler.validate()`
+(`biweeklybudget/flaskapp/views/transactions.py:280`) does
+`Decimal(data['amount']) == Decimal('0')` as its first numeric check. `Decimal('1,234.56')`
+raises `decimal.InvalidOperation`, which propagates out of `post()` and Flask renders a 500.
+
+The same shape exists in six other validators, which call `float(data['amount'])`
+unguarded: `accounts.py:340,343`, `budgets.py:271,274`, `payperiods.py:256`,
+`scheduled.py:231`, plus `transactions.py:293,317,320` for budget-split amounts.
+
+**Decision**: Two independent fixes, both required.
+1. Normalize currency values into a canonical numeric string *before* `validate()` is
+   called, so the raw user string never reaches a bare `Decimal()`/`float()`.
+2. Wrap `validate()` in the same `try`/`except` that already guards `submit()`, so a
+   future unguarded conversion degrades to a form error rather than a 500.
+
+**Rationale**: (1) alone leaves the 500 class of bug one careless line away from
+returning; (2) alone would turn the reported crash into an unhelpful error banner rather
+than accepting the value the user typed. FR-005 requires "never an unhandled server
+error", which only (2) can guarantee.
+
+**Alternatives considered**: A Flask `errorhandler(500)` returning JSON — rejected: it
+hides genuine server bugs behind a form-shaped response across the whole app, and the
+constitution's financial-correctness stance argues for failing loudly everywhere except
+the one path we have deliberately reasoned about.
+
+---
+
+## R-2: Root cause of the "bare integer rejected" defect
+
+**Finding**: `FormHandlerView._validate_float()`
+(`formhandlerview.py:120`) asserts `data[key].startswith('%s' % x)` after `x = float(...)`.
+For input `123`, `x` is `123.0` and `'123'.startswith('123.0')` is `False`, so the field
+is rejected with `Invalid float value: "123"`. Any whole number is rejected; `123.0` is
+required. This helper guards BoM Item `unit_cost` (`projects.py:423`) and the four Fuel
+Log numeric fields (`fuel.py:290-293`).
+
+`_validate_int()` has the analogous `assert data[key] == '%d' % x`, which is correct for
+integers and stays as-is.
+
+**Decision**: Reimplement `_validate_float()` on top of the new parser; drop the
+`startswith` round-trip assertion entirely.
+
+**Rationale**: The assertion was trying to catch "`float()` silently accepted something
+that isn't really this number" — `float('1e5')`, `float('nan')`, `float('  1  ')`. The new
+parser rejects those cases outright and by construction, so the assertion is dead weight
+that only produces false rejections.
+
+**Alternatives considered**: Loosening the assertion to `float(data[key]) == x` — rejected
+as tautological, and it would still leave `nan`/`inf` accepted.
+
+---
+
+## R-3: Server-side parsing library
+
+**Decision**: Use `babel.numbers.parse_decimal(value, locale=..., strict=True)` as the
+parsing core, wrapped in a project function that pre-cleans the input.
+
+**Rationale**:
+- Babel 2.18.0 is **already a direct dependency** (`requirements.txt:13`) and already
+  supplies this project's currency *formatting* (`biweeklybudget/utils.py:90`
+  `fmt_currency` → `babel.numbers.format_currency`). Parsing with the same library against
+  the same `settings.LOCALE_NAME` makes round-tripping consistent by construction, and adds
+  zero dependencies (AGPL-compatibility question does not arise).
+- It returns an exact `Decimal`, satisfying FR-007 (no binary float rounding).
+- `strict=True` rejects ambiguous grouping — verified empirically:
+
+  | Input | `strict=False` | `strict=True` |
+  |-------|----------------|---------------|
+  | `1,234.56` | `1234.56` | `1234.56` |
+  | `1,23,4.56` | `1234.56` (silently!) | rejected |
+  | `10,00` | `1000` (silently!) | rejected |
+  | `1,234,` | `1234` (silently!) | rejected |
+  | `,123` | `123` (silently!) | rejected |
+
+  The `strict=False` column is exactly the silent-corruption failure mode User Story 4 and
+  FR-004 exist to prevent. **`strict=True` is non-negotiable here.**
+- It is locale-parameterized, which is how FR-008 / SC-006 are met: the same call works for
+  `de_DE` (`1.234,56` → `1234.56`) with no code change.
+
+**Alternatives considered**:
+- Hand-rolled regex — rejected: reimplements grouping validation this project would then
+  own and get wrong, and hard-codes US conventions against the explicit i18n requirement.
+- `locale.atof` — rejected: depends on process-global locale state, returns a float (loses
+  cents), and requires the locale to be installed in the OS.
+- `Decimal(value.replace(',', ''))` — rejected: this *is* the `strict=False` column above;
+  it turns `10,00` into 1000.
+
+---
+
+## R-4: What Babel does not handle, and the pre-clean rules
+
+Babel's `parse_decimal` rejects the currency symbol, spaces-as-separators, and
+parentheses-negatives — all three named in FR-003. A pre-clean step handles them, then
+hands a Babel-parseable string to `parse_decimal(strict=True)`.
+
+**Decision** — pre-clean, in this order:
+
+1. Normalize all Unicode space variants (`U+00A0` NBSP, `U+2009` thin, `U+202F` narrow
+   NBSP, `U+2007` figure space, tab) to ASCII space, then strip leading/trailing whitespace.
+2. If the value is wrapped in `(` … `)`, remove them and record a negation.
+3. Repeatedly strip a leading/trailing currency symbol (from
+   `babel.numbers.get_currency_symbol(settings.CURRENCY_CODE, settings.LOCALE_NAME)`), the
+   ISO code itself, and a leading `+`/`-` sign, until the string stops changing. Looping is
+   required so that `-$1,234.56` works: a single pass that takes the sign first leaves
+   `$1,234.56`, which Babel rejects. **This was found by prototyping — a single-pass
+   implementation fails this exact case.**
+4. Replace the remaining internal ASCII spaces with the locale's group separator
+   (`Locale.parse(...).number_symbols['latn']['group']`), then hand to Babel.
+5. An empty string at this point is an error, not zero.
+
+**Rationale for step 4** (the non-obvious one): the naive reading of "accept spaces as
+separators" is "delete all spaces", which turns `1 2 3` into `123` — a number the user
+plainly did not type. Rewriting spaces *into* the locale's group separator instead means
+Babel's `strict=True` grouping validation applies to space-separated input too: `1 234.56`
+→ `1,234.56` → `1234.56`, while `1 2 3` → `1,2,3` → rejected. One rule, both behaviors,
+and it is automatically correct for locales where space *is* the group separator.
+
+**Verified prototype results** (locale `en_US`, currency `USD`):
+
+| Input | Result | | Input | Result |
+|-------|--------|-|-------|--------|
+| `123` | `123` | | `1 2 3` | rejected |
+| `123.45` | `123.45` | | `1,23,4.56` | rejected |
+| `1,234.56` | `1234.56` | | `1.2.3` | rejected |
+| `1 234.56` | `1234.56` | | `abc` | rejected |
+| `$1,234.56` | `1234.56` | | `` (empty) | rejected |
+| `$ 1,234.56` | `1234.56` | | `$` | rejected |
+| `-$1,234.56` | `-1234.56` | | `1,234,` | rejected |
+| `(1,234.56)` | `-1234.56` | | `5-` | rejected |
+| `($1,234.56)` | `-1234.56` | | `-(5)` | rejected |
+| `+123` | `123` | | `1.23456` | `1.23456` |
+| `-0.00` | `0.00` | | ` 1 234.56 ` | `1234.56` |
+
+`-0.00` parsing to `Decimal('0.00')` is correct and required: it compares equal to
+`Decimal('0')`, so existing "amount cannot be zero" checks keep firing (spec edge case).
+
+`de_DE` spot-check confirms locale independence: `1.234,56` → `1234.56`,
+`1 234,56` → `1234.56`, `1,234.56` → rejected.
+
+---
+
+## R-5: Where server-side normalization happens ("as few places as possible")
+
+**Finding**: There are 30+ sites that convert a form string to a number, split across
+`validate()` and `submit()` in 13 form handlers. Normalizing at each site would be 30 edits
+and 30 chances to miss one — the opposite of what the issue asks for.
+
+**Decision**: Normalize **once**, in `FormHandlerView.post()`, before `validate()` runs.
+`FormHandlerView` gains a `currency_fields` class attribute (a list of field names); each
+handler subclass declares its own. `post()` walks that list, replaces each present,
+non-blank value in `data` with its canonical string form, and collects a per-field error
+for any value that will not parse — returning those errors as a normal form-validation
+response without ever calling `validate()`.
+
+**Consequences**: every existing `Decimal(data['amount'])` and `float(data['amount'])` in
+both `validate()` and `submit()` keeps working unchanged, because by the time it runs the
+string is already canonical. The change is one method plus one declarative line per
+handler, and a reviewer can enumerate every currency field by grepping `currency_fields`
+(SC-005).
+
+**Blank values are left untouched**, so each field's existing "blank means zero" /
+"blank is an error" / "blank means omit" semantics are preserved exactly (spec Assumptions).
+
+**Two cases do not fit the flat list**, and are handled explicitly:
+- `TransactionFormHandler` — budget split amounts arrive as a `budgets` dict of
+  `{budget_id: amount}`. The handler overrides the normalization hook to call `super()`
+  and then normalize the dict's values.
+- `PayoffSettingsFormHandler` (`credit_payoffs.py:171`) is a plain `MethodView`, not a
+  `FormHandlerView`, and stores its amounts as a JSON blob in `DBSetting`. It normalizes
+  on the way in, so the stored blob is always canonical. This matters more than it looks:
+  `_payment_settings_dict()` (`credit_payoffs.py:137,142`) calls `Decimal(i['amount'])`
+  while *rendering the credit-payoff page*, so a bad stored value breaks a whole page,
+  not just a form.
+
+**Alternatives considered**:
+- A custom `CurrencyField` type / WTForms-style form layer — rejected: the project has no
+  form-object layer, and introducing one is a far larger change than the issue warrants
+  (constitution: complexity must be justified).
+- Normalizing in the browser only, submitting canonical values — rejected outright: it
+  leaves every endpoint crashable by any non-browser client, and FR-005/edge cases require
+  server-side handling.
+
+---
+
+## R-6: Client-side mirror
+
+**Finding**: The browser converts currency strings to numbers in exactly one file:
+`transactions_modal.js`, at `validateTransModalSplits()` (lines 265, 268) and
+`transModalSplitBudgetChanged()` (lines 339, 343), all via `parseFloat()`. `parseFloat`
+truncates at the first comma — `parseFloat('1,234.56')` is `1`. So a user entering
+`1,234.56` in a split transaction is told the allocations do not sum, and Save is
+disabled; the server fix alone would never be reachable in that flow (User Story 5).
+
+**Decision**: Add `parse_currency(value)` to `biweeklybudget/flaskapp/static/js/custom.js`
+as the sibling of the existing `fmt_currency(value)`, returning `null` for input it cannot
+interpret. Replace all four `parseFloat` calls with it. Separators are discovered from
+`Intl.NumberFormat(LOCALE_NAME).formatToParts(...)` rather than hard-coded, mirroring the
+server's locale parameterization.
+
+**Rationale for `custom.js`**: it is already loaded on every page by `base.html`, already
+holds the formatting counterpart, and already receives `LOCALE_NAME` / `CURRENCY_CODE` /
+`CURRENCY_SYMBOL` as globals from the template. No new file, no new `<script>` tag, and
+`docs/make_jsdoc.py` auto-discovers the file so documentation regenerates for free.
+
+**Verification**: this repository has no JavaScript unit-test harness, and introducing one
+is out of scope. The JS parser is therefore verified through the Selenium acceptance tests
+that the issue explicitly asks for — which is the stronger test anyway, since it exercises
+the real page.
+
+---
+
+## R-7: Error message wording (FR-012)
+
+**Decision**: Replace `Invalid float value: "%s"` / `Invalid Decimal value: "%s"` with
+`Invalid amount: "%s"` for currency fields and `Invalid number: "%s"` for the non-currency
+numeric fields (fuel gallons, reported MPG).
+
+**Rationale**: "float" and "Decimal" are Python type names leaking into a user-facing
+message. Existing acceptance tests assert on the old strings and must be updated in the
+same change.
+
+---
+
+## R-8: Scope of non-currency numeric fields
+
+**Finding**: Fuel Log `gallons` and `reported_mpg` are not currency, but they are validated
+by the same `_validate_float` whose `startswith` assertion causes the bare-integer defect.
+Entering `10` gallons is rejected today.
+
+**Decision**: In scope for the bare-integer fix. They go through the same parser (a stray
+currency symbol on a gallons field is harmless to accept) but are declared separately from
+`currency_fields` so the distinction stays visible, and they get the "number" rather than
+"amount" error wording.
+
+---
+
+## R-9: Testing approach
+
+**Decision**:
+- **Unit tests** (`biweeklybudget/tests/unit/test_utils.py`) — table-driven over the
+  accept/reject matrix in R-4, plus a `de_DE` case proving locale parameterization
+  (SC-006) and a `Decimal`-identity case proving no float rounding (FR-007).
+- **Unit tests** for the `FormHandlerView` normalization hook, using a stub subclass:
+  canonicalization, blank pass-through, error collection, and that `validate()` is not
+  called when normalization fails.
+- **Acceptance (browser) tests** — required by the issue and FR-011. One
+  separator-formatted round trip per form covering the FR-009 inventory; plus, on the
+  Transaction modal, a bare-integer case, a malformed-input case asserting a field error
+  and no 500 and no new DB row, and a budget-split case exercising the client-side parser
+  (User Story 5).
+
+**Rationale**: The unit tests pin the parser's exact semantics cheaply; the browser tests
+prove the wiring, which is where this feature can actually still be broken. The
+constitution's Test Gate requires the full unit and acceptance suites to pass before the
+feature is complete.
+
+**Existing tests to update**: acceptance tests asserting the old `Invalid float value:` /
+`Invalid Decimal value:` message text.
+
+---
+
+## R-10: Schema, version, and documentation obligations
+
+- **Schema**: no model changes, so no Alembic migration (constitution III does not apply).
+  The `migrations` tox env should still pass untouched.
+- **Version**: `biweeklybudget/version.py` is at `1.6.2`. This adds user-visible accepted
+  behavior beyond a pure bug fix, so **1.7.0** per SemVer, with a matching `CHANGES.rst`
+  entry (constitution VI).
+- **Docs** (constitution IV): `docs/source/app_usage.rst` has a localization section that
+  documents currency *formatting*; it gains a subsection documenting accepted *input*
+  formats. `biweeklybudget.utils.rst` regenerates via `sphinx-apidoc -f` in `tox -e docs`.
+  `jsdoc.custom.rst` regenerates via `tox -e jsdoc`; `node` and `jsdoc` are present on this
+  machine, so the regenerated file is committed rather than hand-written.
+
+---
+
+## Unresolved
+
+None. No `NEEDS CLARIFICATION` items remain from Technical Context.

--- a/specs/20260906-155913-currency-input-normalization/spec.md
+++ b/specs/20260906-155913-currency-input-normalization/spec.md
@@ -1,0 +1,285 @@
+# Feature Specification: Currency Value Input Normalization
+
+**Feature Branch**: `robot-army/issue-323-currency-value-input-normalization`
+
+**Created**: 2026-09-06
+
+**Status**: Draft
+
+**Input**: GitHub issue [jantman/biweeklybudget#323](https://github.com/jantman/biweeklybudget/issues/323) — "Currency Value Input Normalization"
+
+> Right now, inputting a currency value in the UI (such as the Amount and Sales Tax
+> fields in the new transaction form) results in a 500 Internal Server Error if the
+> value includes commas as separators, such as `1,234.56`.
+>
+> Also, many of the currency value inputs in the UI do not accept bare integers without
+> an error; i.e. they don't accept `123` but rather require `123.0`.
+>
+> All currency inputs need to be normalized so that they accept common formatting (i.e.
+> bare integers, commas as separators, spaces as separators). This must also take form
+> validation into account, and will need actual browser tests to ensure it is
+> functional. At this time only US currency formatting is in-scope, but normalization
+> should be performed in as few places as possible using specific reused
+> functions/methods, so that it can be extended for i18n in the future if needed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Entering a thousands-separated amount does not break the application (Priority: P1)
+
+A user adding a transaction types the amount the way it is printed on their receipt —
+`1,234.56` — into the Amount field and saves the form. The transaction is created with
+the amount 1234.56.
+
+**Why this priority**: This is the reported defect. Today the same action produces a 500
+Internal Server Error page with no saved record and no explanation, which is both data
+loss (the typed form is gone) and the worst possible failure mode for a financially
+sensitive application. Nothing else in this feature matters if this still crashes.
+
+**Independent Test**: Open the Add Transaction modal in a browser, type `1,234.56` into
+Amount, save, and confirm the transaction is persisted with amount 1234.56 and no error
+is shown. Delivers the entire user-visible value of the issue on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Add Transaction modal is open, **When** the user enters `1,234.56` as
+   the Amount and otherwise-valid values for the remaining fields and saves, **Then**
+   the transaction is saved with an amount of 1234.56 and the modal reports success.
+2. **Given** the Add Transaction modal is open, **When** the user enters `1,234.56` as
+   the Amount, **Then** no server error page is produced under any circumstances —
+   input that cannot be interpreted produces a field-level validation message, never an
+   Internal Server Error.
+3. **Given** any currency input in the application, **When** the user enters a value
+   containing thousands separators, **Then** the value is interpreted with the
+   separators removed.
+
+---
+
+### User Story 2 - Entering a bare integer amount is accepted (Priority: P1)
+
+A user enters a whole-dollar amount as `123` rather than `123.0` and the form accepts
+it.
+
+**Why this priority**: Second half of the reported defect, and the far more common daily
+annoyance — whole-dollar amounts are typical. It is independently valuable and
+independently testable, and shares the same normalization machinery as Story 1.
+
+**Independent Test**: In a browser, enter `123` into each affected currency field and
+confirm the value saves rather than producing "Invalid float value" / "Invalid Decimal
+value" style validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Add/Edit Fuel Fill form, **When** the user enters `123` for Total Cost,
+   **Then** the value is accepted and stored as 123.00 without a validation error.
+2. **Given** the BoM Item form, **When** the user enters `40` for Unit Cost, **Then** the
+   value is accepted and stored as 40.00.
+3. **Given** any currency input in the application, **When** the user enters a value with
+   no decimal point, **Then** it is accepted and interpreted as a whole-unit amount.
+
+---
+
+### User Story 3 - Common incidental formatting is tolerated across every currency input (Priority: P2)
+
+A user pastes or types a currency value that carries the incidental formatting people
+actually produce — a leading currency symbol, surrounding or embedded spaces, a leading
+`+`, parentheses for a negative — and the application interprets it rather than
+rejecting it.
+
+**Why this priority**: This generalizes the fix from the two reported symptoms to the
+class of problem, which is what the issue asks for ("accept common formatting"). It is
+lower priority than P1 because these forms are less common than the two named ones, but
+it is what makes the fix feel finished rather than spot-patched.
+
+**Independent Test**: Feed a table of formatted inputs through a single currency form and
+confirm each is interpreted as the expected numeric value.
+
+**Acceptance Scenarios**:
+
+1. **Given** any currency input, **When** the user enters `$1,234.56`, **Then** it is
+   interpreted as 1234.56.
+2. **Given** any currency input, **When** the user enters ` 1 234.56 ` (spaces as
+   separators, surrounding whitespace), **Then** it is interpreted as 1234.56.
+3. **Given** any currency input, **When** the user enters `-1,234.56`, **Then** it is
+   interpreted as -1234.56.
+4. **Given** any currency input, **When** the user enters `(1,234.56)`, **Then** it is
+   interpreted as -1234.56.
+
+---
+
+### User Story 4 - Malformed input is rejected clearly, not silently mangled (Priority: P1)
+
+A user enters something that is not a currency value — `abc`, `1.2.3`, `1,23.456,7`, or
+an empty string in a required field — and receives a specific, field-level validation
+message telling them the value is not a valid amount. No value is guessed at and no
+record is saved.
+
+**Why this priority**: Equal in priority to the acceptance stories. A normalization
+routine that is too permissive is worse than the current bug: this application computes
+the author's real finances, and silently reading `1.2.3` as `1.2` would corrupt records
+in a way no error message would ever surface. Rejection behavior must ship with
+acceptance behavior.
+
+**Independent Test**: Enter each malformed value into a currency field, save, and confirm
+a field-level error is displayed, the record is not saved, and no server error occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Add Transaction modal, **When** the user enters `abc` as the Amount and
+   saves, **Then** a validation error is shown against the Amount field and no
+   transaction is created.
+2. **Given** the Add Transaction modal, **When** the user enters `1.2.3` as the Amount and
+   saves, **Then** a validation error is shown against the Amount field and no
+   transaction is created.
+3. **Given** any currency input, **When** the user enters a value the system cannot
+   interpret, **Then** the response is a validation message naming the field, never a
+   500 Internal Server Error and never a silently altered amount.
+
+---
+
+### User Story 5 - Client-side feedback agrees with what the server will accept (Priority: P2)
+
+A user entering a split transaction sees the running "sum of budget allocations must
+equal transaction amount" check treat `1,234.56` and `1234.56` identically, so the Save
+button is not disabled for a value the server would have accepted.
+
+**Why this priority**: Without this, the P1 fixes are unreachable in the split-transaction
+flow — in-browser validation blocks submission before the server ever sees the value. It
+is P2 rather than P1 only because it affects one flow rather than every form.
+
+**Independent Test**: In a browser, open the Add Transaction modal, check "Budget Split?",
+enter `1,234.56` as the Amount and matching separator-formatted allocations, and confirm
+the Save button stays enabled and the transaction saves.
+
+**Acceptance Scenarios**:
+
+1. **Given** a split transaction with Amount `1,234.56` and a single allocation of
+   `1,234.56`, **When** the allocation field loses focus, **Then** no mismatch error is
+   shown and Save remains enabled.
+2. **Given** a split transaction with Amount `1,234.56`, **When** a budget row's amount
+   is auto-filled with the remainder, **Then** the auto-filled figure reflects the
+   normalized amount rather than a truncated one.
+
+---
+
+### Edge Cases
+
+- **Empty and whitespace-only values**: A currency field that is optional (for example
+  Sales Tax) and left blank continues to behave as it does today — treated as zero or
+  omitted, per the existing behavior of that field. A required currency field left blank
+  produces its existing "cannot be empty" style error, not a parse error.
+- **Value that is only a currency symbol** (`$`, `$ `): rejected as not a valid amount.
+- **Separators in impossible positions** (`1,23,4.56`, `,123`, `1,234,`): the system must
+  decide deterministically and document the decision; the safe default is rejection,
+  since a user who typed this cannot be assumed to have meant any particular number.
+- **More than two decimal places** (`1.23456`): accepted at the precision the underlying
+  field already supports; normalization does not add rounding behavior that does not
+  exist today.
+- **Very large values**: values beyond the precision the storage supports fail with a
+  validation error rather than being silently truncated.
+- **Negative zero and `-0.00`**: treated as zero, so "amount cannot be zero" checks still
+  fire.
+- **Values arriving from a non-browser client**: the API endpoints accept the same
+  formatted values as the browser forms, because normalization happens where the value is
+  validated, not in the browser alone.
+- **Fields that are numeric but not currency** (fuel gallons, reported MPG): these share
+  the same validation helper as currency fields and today reject bare integers for the
+  same reason. They must not regress, and it is acceptable for them to gain the same
+  tolerance.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a single, reusable normalization routine on the
+  server that converts a user-supplied currency string into an exact decimal value, and
+  every server-side currency field MUST obtain its value through that routine rather than
+  converting the raw string itself.
+- **FR-002**: The system MUST provide a corresponding single, reusable normalization
+  routine in the browser, and every in-browser currency check MUST use it, so that
+  client-side and server-side interpretation of a given string cannot diverge.
+- **FR-003**: Normalization MUST accept, for US formatting: bare integers (`123`),
+  decimal values (`123.45`), comma thousands separators (`1,234.56`), space thousands
+  separators (`1 234.56`), a leading or trailing currency symbol, leading and trailing
+  whitespace, an explicit leading `+` or `-` sign, and parentheses denoting a negative
+  value.
+- **FR-004**: Normalization MUST reject any value it cannot interpret unambiguously, and
+  MUST signal rejection to its caller distinguishably from a successfully parsed value —
+  it MUST NOT return a guessed number, a zero, or a partially-parsed prefix.
+- **FR-005**: Every currency form field in the application MUST validate its input before
+  any conversion is attempted, such that a malformed value produces a field-level
+  validation error in the form response and never an unhandled server error.
+- **FR-006**: Validation MUST NOT reject a value merely because its textual form differs
+  from the canonical rendering of its numeric value; in particular a whole-number entry
+  MUST be accepted.
+- **FR-007**: Normalized values MUST be carried through to storage as exact decimal
+  amounts, with no loss of cents and no binary-floating-point rounding introduced by the
+  normalization step itself.
+- **FR-008**: The normalization behavior MUST be defined in terms of a single, replaceable
+  set of locale conventions (decimal separator, grouping separators, currency symbol,
+  negative forms), so that support for a second locale is a matter of supplying different
+  conventions rather than changing every call site.
+- **FR-009**: The following currency inputs MUST all accept normalized input: Transaction
+  amount and sales tax; per-budget split allocation amounts on a transaction; Scheduled
+  Transaction amount and sales tax; the pay-period "scheduled to transaction" amount and
+  sales tax; the pay-period "skip scheduled transaction" amount; Budget starting balance
+  and current balance; Budget transfer amount; Account credit limit, APR and prime rate
+  margin; Account transfer amount; Fuel Fill cost per unit and total cost; BoM Item unit
+  cost; Credit payoff interest charge; and credit payoff payment-increase and one-time
+  payment amounts.
+- **FR-010**: Existing accepted input forms MUST continue to be accepted — this feature
+  only widens what is accepted; no value that is valid today may become invalid.
+- **FR-011**: Behavior MUST be verified by automated browser tests that drive real form
+  submissions for the accepting cases and the rejecting cases, in addition to unit tests
+  of the normalization routines themselves.
+- **FR-012**: User-facing validation messages for a rejected currency value MUST identify
+  the offending field and state that the value is not a valid amount, in place of the
+  current type-implementation-flavored wording.
+
+### Key Entities
+
+- **Currency input value**: A user-supplied string intended to denote a monetary amount.
+  Has a raw form (what was typed) and a normalized form (an exact decimal). May be
+  invalid, in which case it has no normalized form.
+- **Locale conventions**: The set of rules that determine how a raw form maps to a
+  normalized form — decimal separator, grouping separator(s), currency symbol, and the
+  accepted ways of writing a negative. Exactly one set (US) is in scope; the structure
+  must permit others.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Entering `1,234.56` into any currency field in the application and
+  submitting produces either a saved record with the value 1234.56 or a field-level
+  validation message — in zero cases an Internal Server Error.
+- **SC-002**: Entering a bare whole number into any currency field in the application and
+  submitting saves that amount; zero currency fields require a trailing `.0`.
+- **SC-003**: 100% of the currency inputs enumerated in FR-009 are covered by an
+  automated test that submits a separator-formatted value and asserts the persisted
+  result.
+- **SC-004**: Every malformed input in the project's agreed rejection set produces a
+  field-level validation message and leaves the database unchanged, in 100% of cases.
+- **SC-005**: A reviewer can enumerate every place currency strings are converted to
+  numbers by finding the callers of one server routine and one browser routine.
+- **SC-006**: Adding a second locale's conventions requires no change to any form,
+  validator, or view — only the addition of a conventions definition.
+- **SC-007**: The full unit and acceptance suites pass with the change in place.
+
+## Assumptions
+
+- Only US English currency conventions are in scope: `.` as the decimal separator, `,`
+  and space as grouping separators, `$` as the currency symbol. The existing
+  `CURRENCY_SYM` / locale settings remain the source of the displayed symbol.
+- The set of currency inputs in FR-009 is the set discoverable in the current UI; if
+  implementation reveals additional ones, they are in scope and the list is extended.
+- The application's existing per-field semantics are unchanged — which fields are
+  required, which default to zero when blank, and which reject zero or negative values
+  all stay exactly as they are. This feature changes only how a supplied string is turned
+  into a number.
+- Fuel Fill gallons and reported MPG are not currency, but they share the numeric
+  validation helper whose strictness causes the bare-integer defect; they are treated as
+  in scope for the bare-integer fix and must not regress.
+- Browser tests use the project's existing Selenium-based acceptance test infrastructure
+  and the existing test database fixtures; no new test framework is introduced.
+- Values are normalized at validation time on the server, so any non-browser client of
+  the form endpoints benefits from the same tolerance without a separate change.

--- a/specs/20260906-155913-currency-input-normalization/tasks.md
+++ b/specs/20260906-155913-currency-input-normalization/tasks.md
@@ -1,0 +1,249 @@
+---
+
+description: "Task list for Currency Value Input Normalization"
+---
+
+# Tasks: Currency Value Input Normalization
+
+**Input**: Design documents from `specs/20260906-155913-currency-input-normalization/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/)
+
+**Tests**: **REQUIRED**, not optional, for this feature. The issue explicitly asks for
+"actual browser tests"; spec FR-011 mandates them; and constitution principle II (The Test
+Gate, NON-NEGOTIABLE) requires the full unit and acceptance suites to pass before the
+feature is complete.
+
+**Organization**: Tasks are grouped by user story. Note the shape of this particular
+feature: Phase 2 is unusually heavy and Phases 3–7 are unusually light, because a single
+parser plus a single interception point is what makes all five stories true. The story
+phases are where each story gets *wired up and proven*, which is where it can still be
+broken.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US5)
+- Exact file paths are given in every task
+
+## Path Conventions
+
+Single Python package at the repository root. Server code under `biweeklybudget/`,
+browser code under `biweeklybudget/flaskapp/static/js/`, tests under
+`biweeklybudget/tests/{unit,acceptance}/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Working environment for the suites this feature must keep green.
+
+- [ ] T001 Start the test MariaDB container and export the test DB environment variables per `CLAUDE.md`, then run `python dev/setup_test_db.py` from the repo root to create `budgettest`, `alembicLeft`, and `alembicRight`
+- [ ] T002 Establish the pre-change baseline: run `tox -e py314` redirecting full output to a scratchpad file, and record which tests pass now so post-change failures are attributable to this feature
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The parser and the single interception point. Everything else is wiring.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### The parser
+
+- [ ] T003 Add `CurrencyParseError(ValueError)` and `parse_currency(value)` to `biweeklybudget/utils.py`, directly below the existing `fmt_currency()`, implementing the 8-step algorithm in `contracts/parse_currency-python.md`: normalize Unicode spaces, strip surrounding parentheses as negation, **loop** stripping currency symbol / ISO code / sign until stable, reject empty, rewrite remaining internal spaces to the locale group separator, then `babel.numbers.parse_decimal(s, locale=settings.LOCALE_NAME, strict=True)`, then apply negation
+- [ ] T004 [P] Add the `parse_currency` accept-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, table-driven over every accepting row of the matrix in `contracts/parse_currency-python.md`, asserting exact `Decimal` equality **and** `str()` form (so `123` stays `Decimal('123')`, not `Decimal('123.0')`)
+- [ ] T005 [P] Add the `parse_currency` reject-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, asserting `CurrencyParseError` for every rejecting row: `1 2 3`, `1,23,4.56`, `10,00`, `1,234,`, `,123`, `1.2.3`, `abc`, `''`, `'   '`, `'$'`, `5-`, `-(5)`, `1e5`, `nan`, `inf`, `None`, and a non-string `123`
+- [ ] T006 [P] Add locale-independence and exactness unit tests to `biweeklybudget/tests/unit/test_utils.py`: with `LOCALE_NAME`/`CURRENCY_CODE` patched to `de_DE`/`EUR`, assert `1.234,56` → `Decimal('1234.56')` and `1,234.56` raises (proves SC-006); and assert `parse_currency('0.1') + parse_currency('0.2') == Decimal('0.3')` (proves FR-007 — no binary float anywhere)
+
+### The interception point
+
+- [ ] T007 Add `currency_fields = []` and `decimal_fields = []` class attributes and the `normalize_currency(self, data)` method to `FormHandlerView` in `biweeklybudget/flaskapp/views/formhandlerview.py`, per rules N1–N7 in `contracts/form-handler-normalization.md` — skip absent fields, leave blank/whitespace values untouched, replace parseable values with `str(parse_currency(v))`, accumulate `Invalid amount: "%s"` / `Invalid number: "%s"` errors without short-circuiting
+- [ ] T008 Wire `normalize_currency()` into `FormHandlerView.post()` in `biweeklybudget/flaskapp/views/formhandlerview.py` so it runs before `validate()` and returns `{'success': False, 'errors': errors}` immediately when it finds any, and wrap the `self.validate(data)` call in the same `try`/`except` that already guards `self.submit(data)` (depends on T007)
+- [ ] T009 Rewrite `_validate_decimal()` and `_validate_float()` in `biweeklybudget/flaskapp/views/formhandlerview.py` to use `parse_currency()`; **delete** the `assert data[key].startswith('%s' % x)` line from `_validate_float` — that assertion is the entire bare-integer defect. Leave `_validate_int()` untouched; its round-trip assertion is correct for integers (depends on T003)
+- [ ] T010 Add unit tests for the normalization hook in `biweeklybudget/tests/unit/flaskapp/views/test_formhandlerview.py` using a stub `FormHandlerView` subclass: canonicalization of a good value, blank pass-through, absent-field skip, non-string pass-through, error accumulation across multiple bad fields, and that `validate()` is **not** called when normalization fails (depends on T007, T008)
+
+**Checkpoint**: `tox -e py314` green. Parser and hook exist and are proven; no form uses them yet.
+
+---
+
+## Phase 3: User Story 1 — Thousands separators do not break the app (Priority: P1) 🎯 MVP
+
+**Goal**: `1,234.56` in the Transaction Amount field saves as 1234.56 instead of producing a 500.
+
+**Independent Test**: Open the Add Transaction modal, enter `1,234.56` as Amount with otherwise-valid fields, save, and confirm a `Transaction` row exists with `actual_amount == Decimal('1234.56')` and no error is shown.
+
+- [ ] T011 [US1] Declare `currency_fields = ['amount', 'sales_tax']` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py`
+- [ ] T012 [US1] Override `normalize_currency()` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py` to call `super()` and then normalize the values of the nested `data['budgets']` dict, accumulating failures under `errors['budgets']` — the flat field list cannot reach these, and `validate()` sums them at line 293 (depends on T011)
+- [ ] T013 [US1] Add acceptance test class `TestTransModalCurrencyNormalization` to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` driving the Add Transaction modal with Amount `1,234.56`, asserting the saved `Transaction.actual_amount == Decimal('1234.56')` and that the response is not a server error (depends on T011)
+- [ ] T014 [P] [US1] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` covering the remaining accepted formats on the Amount field — `$1,234.56`, ` 1 234.56 `, `(1,234.56)` → `-1234.56` — one submission each (depends on T013)
+
+**Checkpoint**: The reported 500 is gone. SC-001 holds for the Transaction form.
+
+---
+
+## Phase 4: User Story 2 — Bare integers are accepted (Priority: P1)
+
+**Goal**: `123` is accepted wherever `123.0` is accepted today.
+
+**Independent Test**: Enter `123` for Fuel Log Total Cost and `40` for BoM Item Unit Cost; both save rather than returning "Invalid float value".
+
+- [ ] T015 [P] [US2] Declare `currency_fields = ['cost_per_gallon', 'total_cost']` and `decimal_fields = ['gallons', 'reported_mpg']` on `FuelLogFormHandler` in `biweeklybudget/flaskapp/views/fuel.py`
+- [ ] T016 [P] [US2] Declare `currency_fields = ['unit_cost']` on `BoMItemFormHandler` in `biweeklybudget/flaskapp/views/projects.py`
+- [ ] T017 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py` submitting the Fuel Log modal with whole-number Total Cost `123`, Cost Per Gallon `3`, and Gallons `10`, asserting the saved `FuelFill` values (depends on T015)
+- [ ] T018 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_projects.py` submitting the BoM Item modal with Unit Cost `40`, asserting `BoMItem.unit_cost == Decimal('40')` (depends on T016)
+- [ ] T019 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting the Transaction modal with a bare-integer Amount `123` (depends on T011)
+
+**Checkpoint**: SC-002 holds — no currency field requires a trailing `.0`.
+
+---
+
+## Phase 5: User Story 4 — Malformed input is rejected clearly (Priority: P1)
+
+**Goal**: Bad input produces a field-level error, no saved record, and no 500 — never a guessed number.
+
+**Independent Test**: Submit `abc` and `1.2.3` as a Transaction Amount; each shows a field error on Amount, creates no row, and returns HTTP 200 with a JSON error body.
+
+> Sequenced after US1/US2 deliberately: rejection is only meaningful once acceptance is wired, and it is the guard against this feature's own worst failure mode — silently mangling an amount.
+
+- [ ] T020 [US4] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting Amount `abc`, asserting the Amount field shows `Invalid amount: "abc"`, the form has the `has-error` class, and the `Transaction` count is unchanged (depends on T011)
+- [ ] T021 [P] [US4] Add acceptance tests to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the remaining rejection cases on Amount — `1.2.3`, `10,00`, `1,23,4.56` — each asserting a field error and no new row (depends on T020)
+- [ ] T022 [P] [US4] Update every existing acceptance test that asserts on the old `Invalid float value: "..."` or `Invalid Decimal value: "..."` message text to expect the new `Invalid amount:` / `Invalid number:` wording; find them with `grep -rn 'Invalid float value\|Invalid Decimal value' biweeklybudget/` (depends on T009)
+- [ ] T023 [US4] Add an acceptance test asserting no 500 is produced: post `{'amount': '1,234.56', ...}` directly to `/forms/transaction` with `requests` and assert the status is 200 and the body is JSON, mirroring the existing direct-POST helper usage in `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` (depends on T011)
+
+**Checkpoint**: SC-004 holds. Rejection is as well-pinned as acceptance.
+
+---
+
+## Phase 6: User Story 3 — Every currency input, not just the reported ones (Priority: P2)
+
+**Goal**: The full FR-009 inventory accepts normalized input.
+
+**Independent Test**: Submit a comma-separated value through each remaining form and assert the persisted value.
+
+- [ ] T024 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedTransFormHandler` in `biweeklybudget/flaskapp/views/scheduled.py`
+- [ ] T025 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedToTransFormHandler` and `currency_fields = ['amount']` on `SkipSchedTransFormHandler` in `biweeklybudget/flaskapp/views/payperiods.py`
+- [ ] T026 [P] [US3] Declare `currency_fields = ['starting_balance', 'current_balance']` on `BudgetFormHandler` and `currency_fields = ['amount']` on `BudgetTxfrFormHandler` in `biweeklybudget/flaskapp/views/budgets.py`
+- [ ] T027 [P] [US3] Declare `currency_fields = ['credit_limit', 'apr', 'prime_rate_margin']` on `AccountFormHandler` and `currency_fields = ['amount']` on `AccountTxfrFormHandler` in `biweeklybudget/flaskapp/views/accounts.py` — all five are blank-allowed, so rule N2 must keep the existing `.strip() != ''` guards working, and `submit()`'s ">1 means percent" rate handling must stay unchanged
+- [ ] T028 [US3] Declare `currency_fields = ['interest_amt']` on `AccountOfxFormHandler` in `biweeklybudget/flaskapp/views/credit_payoffs.py`
+- [ ] T029 [US3] Normalize each `increases[]` / `onetimes[]` `amount` in `PayoffSettingsFormHandler.post()` in `biweeklybudget/flaskapp/views/credit_payoffs.py` before the JSON blob is written to `DBSetting`, returning `{'success': False, 'error_message': ...}` for a bad value. This is a plain `MethodView`, so it calls `parse_currency()` directly. Normalizing on write matters because `_payment_settings_dict()` re-parses the blob while *rendering* the credit-payoff page — a bad stored value breaks the whole page (depends on T003)
+- [ ] T030 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_scheduled.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_payperiods.py` (depends on T024, T025)
+- [ ] T031 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_budgets.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_accounts.py` (depends on T026, T027)
+- [ ] T032 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_credit_payoffs.py`, covering both the OFX interest form and the payoff settings form (depends on T028, T029)
+
+**Checkpoint**: SC-003 holds — every FR-009 input has a test that submits a separator-formatted value and asserts the persisted result.
+
+---
+
+## Phase 7: User Story 5 — Client-side agreement (Priority: P2)
+
+**Goal**: In-browser split validation treats `1,234.56` the way the server does, so it stops blocking submissions the server would accept.
+
+**Independent Test**: In the Transaction modal with Budget Split checked, Amount `1,234.56` and one allocation `1,234.56` produce no mismatch error and Save stays enabled.
+
+- [ ] T033 [US5] Add `parse_currency(value)` to `biweeklybudget/flaskapp/static/js/custom.js`, directly below `fmt_currency()`, per `contracts/parse_currency-js.md`: derive separators from `Intl.NumberFormat(LOCALE_NAME).formatToParts()`, use the `CURRENCY_SYMBOL` global, mirror the server's accept/reject rules, and return `null` — never `NaN` — for uninterpretable input
+- [ ] T034 [US5] Replace all four `parseFloat()` calls in `biweeklybudget/flaskapp/static/js/transactions_modal.js` (lines ~265 and ~268 in `validateTransModalSplits()`, ~339 and ~343 in `transModalSplitBudgetChanged()`) with `parse_currency()`, handling `null` explicitly at each site per the table in `contracts/parse_currency-js.md` — skip the remainder auto-fill on `null`, and suppress the mismatch message rather than rendering `NaN` (depends on T033)
+- [ ] T035 [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py`, alongside the existing `TestTransModalBudgetSplits`, checking Budget Split with Amount `1,234.56` and a matching separator-formatted allocation, asserting `#budget-split-feedback` is empty, `#modalSaveButton` is enabled, and the saved `BudgetTransaction` amounts are correct (depends on T034)
+- [ ] T036 [P] [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the split remainder auto-fill with a separator-formatted Amount, asserting the auto-filled allocation is the correct remainder and not a truncated one (depends on T034)
+
+**Checkpoint**: All five user stories functional.
+
+---
+
+## Phase 8: Polish & Completion
+
+**Purpose**: Constitution obligations — docs, version, changelog, and the full test gate.
+
+- [ ] T037 [P] Document accepted currency input formats in `docs/source/app_usage.rst`, as a subsection of the existing localization content, listing the accepted and rejected forms and noting that conventions follow `LOCALE_NAME`
+- [ ] T038 [P] Verify `grep -rn "currency_fields\|decimal_fields" biweeklybudget/flaskapp/views/` enumerates the complete FR-009 inventory from `data-model.md`, and that `grep -n parseFloat biweeklybudget/flaskapp/static/js/transactions_modal.js` returns nothing (SC-005)
+- [ ] T039 Run `tox -e py314` to completion with full output redirected to a scratchpad file; fix every failure and every pycodestyle/pyflakes finding
+- [ ] T040 Run `tox -e acceptance` to completion with full output redirected to a scratchpad file; fix every failure. A timeout is **not** a pass — raise the `pytest.ini` timeout and the tool timeout and re-run rather than narrowing the selection (constitution II) (depends on T039)
+- [ ] T041 [P] Run `tox -e migrations` and confirm it passes unchanged — this feature touches no models, so any failure here is a regression (depends on T039)
+- [ ] T042 Run `tox -e jsdoc` to regenerate `docs/source/jsdoc.custom.rst` for the new JS function and commit the regenerated file (`node` and `jsdoc` are available on this machine) (depends on T033)
+- [ ] T043 Run `tox -e docs` and confirm it builds clean, including the regenerated `docs/source/biweeklybudget.utils.rst` (depends on T037, T042)
+- [ ] T044 Bump `VERSION` in `biweeklybudget/version.py` from `1.6.2` to `1.7.0` and add the matching entry to `CHANGES.rst` in the existing format, referencing issue #323 (depends on T039, T040)
+- [ ] T045 Walk the manual verification table in [quickstart.md](./quickstart.md) against a locally running `flask rundev` instance, confirming all six Transaction-modal rows and the other-form spot checks (depends on T040)
+- [ ] T046 Update this file and [plan.md](./plan.md) to record completion status, then commit, push the branch to `origin`, and open the pull request (depends on all)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** → no dependencies
+- **Phase 2 (Foundational)** → depends on Phase 1; **BLOCKS every user story**
+- **Phase 3 (US1)** → depends on Phase 2. MVP.
+- **Phase 4 (US2)** → depends on Phase 2. Independent of US1 except that T019 reuses the Transaction wiring from T011.
+- **Phase 5 (US4)** → depends on Phase 2 and on US1/US2 wiring existing, since rejection is asserted through those forms
+- **Phase 6 (US3)** → depends on Phase 2 only
+- **Phase 7 (US5)** → depends on Phase 2; the browser tests additionally need US1's Transaction wiring
+- **Phase 8 (Polish)** → depends on all desired stories
+
+### Critical Path
+
+T003 → T007 → T008 → T011 → T013 → … → T039 → T040 → T044 → T046
+
+T003 (the parser) and T007/T008 (the hook) are the only true bottlenecks. Everything from
+Phase 3 onward is wiring and tests over a stable interface.
+
+### Parallel Opportunities
+
+- T004, T005, T006 — three independent test groups over the same new function
+- T015–T019 (US2) and T024–T032 (US3) — each touches a different view or test file
+- T037, T038, T041 in Phase 8
+- Whole phases: US2, US3 and US5 have no dependencies on each other once Phase 2 lands
+
+### Sequential Constraints (same file — do NOT parallelize)
+
+- T007 → T008 → T009 all edit `formhandlerview.py`
+- T011 → T012 both edit `transactions.py`
+- T013, T014, T019, T020, T021, T023, T035, T036 all append to `test_transactions.py`; write them in ID order
+- T033 → T034: `transactions_modal.js` cannot be changed before `custom.js` defines the function
+
+---
+
+## Parallel Example: Phase 2 tests
+
+```bash
+# After T003 lands, these three test groups are independent:
+Task: "parse_currency accept-case unit tests in biweeklybudget/tests/unit/test_utils.py"
+Task: "parse_currency reject-case unit tests in biweeklybudget/tests/unit/test_utils.py"
+Task: "parse_currency locale and exactness unit tests in biweeklybudget/tests/unit/test_utils.py"
+```
+
+## Parallel Example: Phase 6 handler declarations
+
+```bash
+Task: "Declare currency_fields on SchedTransFormHandler in views/scheduled.py"
+Task: "Declare currency_fields on the two payperiods handlers in views/payperiods.py"
+Task: "Declare currency_fields on the two budgets handlers in views/budgets.py"
+Task: "Declare currency_fields on the two accounts handlers in views/accounts.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (Phases 1–3)
+
+Setup → Foundational → US1. At that point the reported 500 is fixed and provable. **Stop
+and validate** before going further.
+
+### Incremental Delivery
+
+1. Phases 1–2 → parser and hook exist, unit-tested, wired to nothing
+2. Phase 3 → US1: the reported crash is gone (MVP)
+3. Phase 4 → US2: the second reported defect is gone
+4. Phase 5 → US4: rejection pinned, so acceptance cannot silently over-reach
+5. Phase 6 → US3: the whole FR-009 inventory
+6. Phase 7 → US5: client and server agree
+7. Phase 8 → docs, version, changelog, full gate, PR
+
+### Notes
+
+- Commit messages use the constitution's `Currency Value Input Normalization - {Milestone}.{Task}` prefix
+- Do not skip T022. The wording change in T009 silently breaks existing acceptance
+  assertions, and those failures will otherwise look like feature bugs
+- Do not weaken `strict=True` in T003 to make a test pass. Without it, Babel reads `10,00`
+  as `1000` — the exact silent-corruption failure this feature exists to prevent

--- a/specs/20260906-155913-currency-input-normalization/tasks.md
+++ b/specs/20260906-155913-currency-input-normalization/tasks.md
@@ -38,8 +38,8 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Purpose**: Working environment for the suites this feature must keep green.
 
-- [ ] T001 Start the test MariaDB container and export the test DB environment variables per `CLAUDE.md`, then run `python dev/setup_test_db.py` from the repo root to create `budgettest`, `alembicLeft`, and `alembicRight`
-- [ ] T002 Establish the pre-change baseline: run `tox -e py314` redirecting full output to a scratchpad file, and record which tests pass now so post-change failures are attributable to this feature
+- [X] T001 Start the test MariaDB container and export the test DB environment variables per `CLAUDE.md`, then run `python dev/setup_test_db.py` from the repo root to create `budgettest`, `alembicLeft`, and `alembicRight`
+- [X] T002 Establish the pre-change baseline: run `tox -e py314` redirecting full output to a scratchpad file, and record which tests pass now so post-change failures are attributable to this feature
 
 ---
 
@@ -51,17 +51,17 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 ### The parser
 
-- [ ] T003 Add `CurrencyParseError(ValueError)` and `parse_currency(value)` to `biweeklybudget/utils.py`, directly below the existing `fmt_currency()`, implementing the 8-step algorithm in `contracts/parse_currency-python.md`: normalize Unicode spaces, strip surrounding parentheses as negation, **loop** stripping currency symbol / ISO code / sign until stable, reject empty, rewrite remaining internal spaces to the locale group separator, then `babel.numbers.parse_decimal(s, locale=settings.LOCALE_NAME, strict=True)`, then apply negation
-- [ ] T004 [P] Add the `parse_currency` accept-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, table-driven over every accepting row of the matrix in `contracts/parse_currency-python.md`, asserting exact `Decimal` equality **and** `str()` form (so `123` stays `Decimal('123')`, not `Decimal('123.0')`)
-- [ ] T005 [P] Add the `parse_currency` reject-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, asserting `CurrencyParseError` for every rejecting row: `1 2 3`, `1,23,4.56`, `10,00`, `1,234,`, `,123`, `1.2.3`, `abc`, `''`, `'   '`, `'$'`, `5-`, `-(5)`, `1e5`, `nan`, `inf`, `None`, and a non-string `123`
-- [ ] T006 [P] Add locale-independence and exactness unit tests to `biweeklybudget/tests/unit/test_utils.py`: with `LOCALE_NAME`/`CURRENCY_CODE` patched to `de_DE`/`EUR`, assert `1.234,56` → `Decimal('1234.56')` and `1,234.56` raises (proves SC-006); and assert `parse_currency('0.1') + parse_currency('0.2') == Decimal('0.3')` (proves FR-007 — no binary float anywhere)
+- [X] T003 Add `CurrencyParseError(ValueError)` and `parse_currency(value)` to `biweeklybudget/utils.py`, directly below the existing `fmt_currency()`, implementing the 8-step algorithm in `contracts/parse_currency-python.md`: normalize Unicode spaces, strip surrounding parentheses as negation, **loop** stripping currency symbol / ISO code / sign until stable, reject empty, rewrite remaining internal spaces to the locale group separator, then `babel.numbers.parse_decimal(s, locale=settings.LOCALE_NAME, strict=True)`, then apply negation
+- [X] T004 [P] Add the `parse_currency` accept-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, table-driven over every accepting row of the matrix in `contracts/parse_currency-python.md`, asserting exact `Decimal` equality **and** `str()` form (so `123` stays `Decimal('123')`, not `Decimal('123.0')`)
+- [X] T005 [P] Add the `parse_currency` reject-case unit tests to `biweeklybudget/tests/unit/test_utils.py`, asserting `CurrencyParseError` for every rejecting row: `1 2 3`, `1,23,4.56`, `10,00`, `1,234,`, `,123`, `1.2.3`, `abc`, `''`, `'   '`, `'$'`, `5-`, `-(5)`, `1e5`, `nan`, `inf`, `None`, and a non-string `123`
+- [X] T006 [P] Add locale-independence and exactness unit tests to `biweeklybudget/tests/unit/test_utils.py`: with `LOCALE_NAME`/`CURRENCY_CODE` patched to `de_DE`/`EUR`, assert `1.234,56` → `Decimal('1234.56')` and `1,234.56` raises (proves SC-006); and assert `parse_currency('0.1') + parse_currency('0.2') == Decimal('0.3')` (proves FR-007 — no binary float anywhere)
 
 ### The interception point
 
-- [ ] T007 Add `currency_fields = []` and `decimal_fields = []` class attributes and the `normalize_currency(self, data)` method to `FormHandlerView` in `biweeklybudget/flaskapp/views/formhandlerview.py`, per rules N1–N7 in `contracts/form-handler-normalization.md` — skip absent fields, leave blank/whitespace values untouched, replace parseable values with `str(parse_currency(v))`, accumulate `Invalid amount: "%s"` / `Invalid number: "%s"` errors without short-circuiting
-- [ ] T008 Wire `normalize_currency()` into `FormHandlerView.post()` in `biweeklybudget/flaskapp/views/formhandlerview.py` so it runs before `validate()` and returns `{'success': False, 'errors': errors}` immediately when it finds any, and wrap the `self.validate(data)` call in the same `try`/`except` that already guards `self.submit(data)` (depends on T007)
-- [ ] T009 Rewrite `_validate_decimal()` and `_validate_float()` in `biweeklybudget/flaskapp/views/formhandlerview.py` to use `parse_currency()`; **delete** the `assert data[key].startswith('%s' % x)` line from `_validate_float` — that assertion is the entire bare-integer defect. Leave `_validate_int()` untouched; its round-trip assertion is correct for integers (depends on T003)
-- [ ] T010 Add unit tests for the normalization hook in `biweeklybudget/tests/unit/flaskapp/views/test_formhandlerview.py` using a stub `FormHandlerView` subclass: canonicalization of a good value, blank pass-through, absent-field skip, non-string pass-through, error accumulation across multiple bad fields, and that `validate()` is **not** called when normalization fails (depends on T007, T008)
+- [X] T007 Add `currency_fields = []` and `decimal_fields = []` class attributes and the `normalize_currency(self, data)` method to `FormHandlerView` in `biweeklybudget/flaskapp/views/formhandlerview.py`, per rules N1–N7 in `contracts/form-handler-normalization.md` — skip absent fields, leave blank/whitespace values untouched, replace parseable values with `str(parse_currency(v))`, accumulate `Invalid amount: "%s"` / `Invalid number: "%s"` errors without short-circuiting
+- [X] T008 Wire `normalize_currency()` into `FormHandlerView.post()` in `biweeklybudget/flaskapp/views/formhandlerview.py` so it runs before `validate()` and returns `{'success': False, 'errors': errors}` immediately when it finds any, and wrap the `self.validate(data)` call in the same `try`/`except` that already guards `self.submit(data)` (depends on T007)
+- [X] T009 Rewrite `_validate_decimal()` and `_validate_float()` in `biweeklybudget/flaskapp/views/formhandlerview.py` to use `parse_currency()`; **delete** the `assert data[key].startswith('%s' % x)` line from `_validate_float` — that assertion is the entire bare-integer defect. Leave `_validate_int()` untouched; its round-trip assertion is correct for integers (depends on T003)
+- [X] T010 Add unit tests for the normalization hook in `biweeklybudget/tests/unit/flaskapp/views/test_formhandlerview.py` using a stub `FormHandlerView` subclass: canonicalization of a good value, blank pass-through, absent-field skip, non-string pass-through, error accumulation across multiple bad fields, and that `validate()` is **not** called when normalization fails (depends on T007, T008)
 
 **Checkpoint**: `tox -e py314` green. Parser and hook exist and are proven; no form uses them yet.
 
@@ -73,10 +73,10 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Independent Test**: Open the Add Transaction modal, enter `1,234.56` as Amount with otherwise-valid fields, save, and confirm a `Transaction` row exists with `actual_amount == Decimal('1234.56')` and no error is shown.
 
-- [ ] T011 [US1] Declare `currency_fields = ['amount', 'sales_tax']` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py`
-- [ ] T012 [US1] Override `normalize_currency()` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py` to call `super()` and then normalize the values of the nested `data['budgets']` dict, accumulating failures under `errors['budgets']` — the flat field list cannot reach these, and `validate()` sums them at line 293 (depends on T011)
-- [ ] T013 [US1] Add acceptance test class `TestTransModalCurrencyNormalization` to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` driving the Add Transaction modal with Amount `1,234.56`, asserting the saved `Transaction.actual_amount == Decimal('1234.56')` and that the response is not a server error (depends on T011)
-- [ ] T014 [P] [US1] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` covering the remaining accepted formats on the Amount field — `$1,234.56`, ` 1 234.56 `, `(1,234.56)` → `-1234.56` — one submission each (depends on T013)
+- [X] T011 [US1] Declare `currency_fields = ['amount', 'sales_tax']` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py`
+- [X] T012 [US1] Override `normalize_currency()` on `TransactionFormHandler` in `biweeklybudget/flaskapp/views/transactions.py` to call `super()` and then normalize the values of the nested `data['budgets']` dict, accumulating failures under `errors['budgets']` — the flat field list cannot reach these, and `validate()` sums them at line 293 (depends on T011)
+- [X] T013 [US1] Add acceptance test class `TestTransModalCurrencyNormalization` to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` driving the Add Transaction modal with Amount `1,234.56`, asserting the saved `Transaction.actual_amount == Decimal('1234.56')` and that the response is not a server error (depends on T011)
+- [X] T014 [P] [US1] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` covering the remaining accepted formats on the Amount field — `$1,234.56`, ` 1 234.56 `, `(1,234.56)` → `-1234.56` — one submission each (depends on T013)
 
 **Checkpoint**: The reported 500 is gone. SC-001 holds for the Transaction form.
 
@@ -88,11 +88,11 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Independent Test**: Enter `123` for Fuel Log Total Cost and `40` for BoM Item Unit Cost; both save rather than returning "Invalid float value".
 
-- [ ] T015 [P] [US2] Declare `currency_fields = ['cost_per_gallon', 'total_cost']` and `decimal_fields = ['gallons', 'reported_mpg']` on `FuelLogFormHandler` in `biweeklybudget/flaskapp/views/fuel.py`
-- [ ] T016 [P] [US2] Declare `currency_fields = ['unit_cost']` on `BoMItemFormHandler` in `biweeklybudget/flaskapp/views/projects.py`
-- [ ] T017 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py` submitting the Fuel Log modal with whole-number Total Cost `123`, Cost Per Gallon `3`, and Gallons `10`, asserting the saved `FuelFill` values (depends on T015)
-- [ ] T018 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_projects.py` submitting the BoM Item modal with Unit Cost `40`, asserting `BoMItem.unit_cost == Decimal('40')` (depends on T016)
-- [ ] T019 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting the Transaction modal with a bare-integer Amount `123` (depends on T011)
+- [X] T015 [P] [US2] Declare `currency_fields = ['cost_per_gallon', 'total_cost']` and `decimal_fields = ['gallons', 'reported_mpg']` on `FuelLogFormHandler` in `biweeklybudget/flaskapp/views/fuel.py`
+- [X] T016 [P] [US2] Declare `currency_fields = ['unit_cost']` on `BoMItemFormHandler` in `biweeklybudget/flaskapp/views/projects.py`
+- [X] T017 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py` submitting the Fuel Log modal with whole-number Total Cost `123`, Cost Per Gallon `3`, and Gallons `10`, asserting the saved `FuelFill` values (depends on T015)
+- [X] T018 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_projects.py` submitting the BoM Item modal with Unit Cost `40`, asserting `BoMItem.unit_cost == Decimal('40')` (depends on T016)
+- [X] T019 [P] [US2] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting the Transaction modal with a bare-integer Amount `123` (depends on T011)
 
 **Checkpoint**: SC-002 holds — no currency field requires a trailing `.0`.
 
@@ -106,10 +106,10 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 > Sequenced after US1/US2 deliberately: rejection is only meaningful once acceptance is wired, and it is the guard against this feature's own worst failure mode — silently mangling an amount.
 
-- [ ] T020 [US4] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting Amount `abc`, asserting the Amount field shows `Invalid amount: "abc"`, the form has the `has-error` class, and the `Transaction` count is unchanged (depends on T011)
-- [ ] T021 [P] [US4] Add acceptance tests to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the remaining rejection cases on Amount — `1.2.3`, `10,00`, `1,23,4.56` — each asserting a field error and no new row (depends on T020)
-- [ ] T022 [P] [US4] Update every existing acceptance test that asserts on the old `Invalid float value: "..."` or `Invalid Decimal value: "..."` message text to expect the new `Invalid amount:` / `Invalid number:` wording; find them with `grep -rn 'Invalid float value\|Invalid Decimal value' biweeklybudget/` (depends on T009)
-- [ ] T023 [US4] Add an acceptance test asserting no 500 is produced: post `{'amount': '1,234.56', ...}` directly to `/forms/transaction` with `requests` and assert the status is 200 and the body is JSON, mirroring the existing direct-POST helper usage in `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` (depends on T011)
+- [X] T020 [US4] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` submitting Amount `abc`, asserting the Amount field shows `Invalid amount: "abc"`, the form has the `has-error` class, and the `Transaction` count is unchanged (depends on T011)
+- [X] T021 [P] [US4] Add acceptance tests to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the remaining rejection cases on Amount — `1.2.3`, `10,00`, `1,23,4.56` — each asserting a field error and no new row (depends on T020)
+- [X] T022 [P] [US4] (No-op: `grep -rn 'Invalid float value\|Invalid Decimal value' biweeklybudget/` found no assertions on the old wording, so nothing needed changing.) Update every existing acceptance test that asserts on the old `Invalid float value: "..."` or `Invalid Decimal value: "..."` message text to expect the new `Invalid amount:` / `Invalid number:` wording; find them with `grep -rn 'Invalid float value\|Invalid Decimal value' biweeklybudget/` (depends on T009)
+- [X] T023 [US4] Add an acceptance test asserting no 500 is produced: post `{'amount': '1,234.56', ...}` directly to `/forms/transaction` with `requests` and assert the status is 200 and the body is JSON, mirroring the existing direct-POST helper usage in `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` (depends on T011)
 
 **Checkpoint**: SC-004 holds. Rejection is as well-pinned as acceptance.
 
@@ -121,15 +121,15 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Independent Test**: Submit a comma-separated value through each remaining form and assert the persisted value.
 
-- [ ] T024 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedTransFormHandler` in `biweeklybudget/flaskapp/views/scheduled.py`
-- [ ] T025 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedToTransFormHandler` and `currency_fields = ['amount']` on `SkipSchedTransFormHandler` in `biweeklybudget/flaskapp/views/payperiods.py`
-- [ ] T026 [P] [US3] Declare `currency_fields = ['starting_balance', 'current_balance']` on `BudgetFormHandler` and `currency_fields = ['amount']` on `BudgetTxfrFormHandler` in `biweeklybudget/flaskapp/views/budgets.py`
-- [ ] T027 [P] [US3] Declare `currency_fields = ['credit_limit', 'apr', 'prime_rate_margin']` on `AccountFormHandler` and `currency_fields = ['amount']` on `AccountTxfrFormHandler` in `biweeklybudget/flaskapp/views/accounts.py` — all five are blank-allowed, so rule N2 must keep the existing `.strip() != ''` guards working, and `submit()`'s ">1 means percent" rate handling must stay unchanged
-- [ ] T028 [US3] Declare `currency_fields = ['interest_amt']` on `AccountOfxFormHandler` in `biweeklybudget/flaskapp/views/credit_payoffs.py`
-- [ ] T029 [US3] Normalize each `increases[]` / `onetimes[]` `amount` in `PayoffSettingsFormHandler.post()` in `biweeklybudget/flaskapp/views/credit_payoffs.py` before the JSON blob is written to `DBSetting`, returning `{'success': False, 'error_message': ...}` for a bad value. This is a plain `MethodView`, so it calls `parse_currency()` directly. Normalizing on write matters because `_payment_settings_dict()` re-parses the blob while *rendering* the credit-payoff page — a bad stored value breaks the whole page (depends on T003)
-- [ ] T030 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_scheduled.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_payperiods.py` (depends on T024, T025)
-- [ ] T031 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_budgets.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_accounts.py` (depends on T026, T027)
-- [ ] T032 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_credit_payoffs.py`, covering both the OFX interest form and the payoff settings form (depends on T028, T029)
+- [X] T024 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedTransFormHandler` in `biweeklybudget/flaskapp/views/scheduled.py`
+- [X] T025 [P] [US3] Declare `currency_fields = ['amount', 'sales_tax']` on `SchedToTransFormHandler` and `currency_fields = ['amount']` on `SkipSchedTransFormHandler` in `biweeklybudget/flaskapp/views/payperiods.py`
+- [X] T026 [P] [US3] Declare `currency_fields = ['starting_balance', 'current_balance']` on `BudgetFormHandler` and `currency_fields = ['amount']` on `BudgetTxfrFormHandler` in `biweeklybudget/flaskapp/views/budgets.py`
+- [X] T027 [P] [US3] Declare `currency_fields = ['credit_limit', 'apr', 'prime_rate_margin']` on `AccountFormHandler` and `currency_fields = ['amount']` on `AccountTxfrFormHandler` in `biweeklybudget/flaskapp/views/accounts.py` — all five are blank-allowed, so rule N2 must keep the existing `.strip() != ''` guards working, and `submit()`'s ">1 means percent" rate handling must stay unchanged
+- [X] T028 [US3] Declare `currency_fields = ['interest_amt']` on `AccountOfxFormHandler` in `biweeklybudget/flaskapp/views/credit_payoffs.py`
+- [X] T029 [US3] Normalize each `increases[]` / `onetimes[]` `amount` in `PayoffSettingsFormHandler.post()` in `biweeklybudget/flaskapp/views/credit_payoffs.py` before the JSON blob is written to `DBSetting`, returning `{'success': False, 'error_message': ...}` for a bad value. This is a plain `MethodView`, so it calls `parse_currency()` directly. Normalizing on write matters because `_payment_settings_dict()` re-parses the blob while *rendering* the credit-payoff page — a bad stored value breaks the whole page (depends on T003)
+- [X] T030 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_scheduled.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_payperiods.py` (depends on T024, T025)
+- [X] T031 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_budgets.py` and `biweeklybudget/tests/acceptance/flaskapp/views/test_accounts.py` (depends on T026, T027)
+- [X] T032 [P] [US3] Add acceptance tests for comma-separated input to `biweeklybudget/tests/acceptance/flaskapp/views/test_credit_payoffs.py`, covering both the OFX interest form and the payoff settings form (depends on T028, T029)
 
 **Checkpoint**: SC-003 holds — every FR-009 input has a test that submits a separator-formatted value and asserts the persisted result.
 
@@ -141,10 +141,10 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Independent Test**: In the Transaction modal with Budget Split checked, Amount `1,234.56` and one allocation `1,234.56` produce no mismatch error and Save stays enabled.
 
-- [ ] T033 [US5] Add `parse_currency(value)` to `biweeklybudget/flaskapp/static/js/custom.js`, directly below `fmt_currency()`, per `contracts/parse_currency-js.md`: derive separators from `Intl.NumberFormat(LOCALE_NAME).formatToParts()`, use the `CURRENCY_SYMBOL` global, mirror the server's accept/reject rules, and return `null` — never `NaN` — for uninterpretable input
-- [ ] T034 [US5] Replace all four `parseFloat()` calls in `biweeklybudget/flaskapp/static/js/transactions_modal.js` (lines ~265 and ~268 in `validateTransModalSplits()`, ~339 and ~343 in `transModalSplitBudgetChanged()`) with `parse_currency()`, handling `null` explicitly at each site per the table in `contracts/parse_currency-js.md` — skip the remainder auto-fill on `null`, and suppress the mismatch message rather than rendering `NaN` (depends on T033)
-- [ ] T035 [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py`, alongside the existing `TestTransModalBudgetSplits`, checking Budget Split with Amount `1,234.56` and a matching separator-formatted allocation, asserting `#budget-split-feedback` is empty, `#modalSaveButton` is enabled, and the saved `BudgetTransaction` amounts are correct (depends on T034)
-- [ ] T036 [P] [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the split remainder auto-fill with a separator-formatted Amount, asserting the auto-filled allocation is the correct remainder and not a truncated one (depends on T034)
+- [X] T033 [US5] Add `parse_currency(value)` to `biweeklybudget/flaskapp/static/js/custom.js`, directly below `fmt_currency()`, per `contracts/parse_currency-js.md`: derive separators from `Intl.NumberFormat(LOCALE_NAME).formatToParts()`, use the `CURRENCY_SYMBOL` global, mirror the server's accept/reject rules, and return `null` — never `NaN` — for uninterpretable input
+- [X] T034 [US5] Replace all four `parseFloat()` calls in `biweeklybudget/flaskapp/static/js/transactions_modal.js` (lines ~265 and ~268 in `validateTransModalSplits()`, ~339 and ~343 in `transModalSplitBudgetChanged()`) with `parse_currency()`, handling `null` explicitly at each site per the table in `contracts/parse_currency-js.md` — skip the remainder auto-fill on `null`, and suppress the mismatch message rather than rendering `NaN` (depends on T033)
+- [X] T035 [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py`, alongside the existing `TestTransModalBudgetSplits`, checking Budget Split with Amount `1,234.56` and a matching separator-formatted allocation, asserting `#budget-split-feedback` is empty, `#modalSaveButton` is enabled, and the saved `BudgetTransaction` amounts are correct (depends on T034)
+- [X] T036 [P] [US5] Add an acceptance test to `biweeklybudget/tests/acceptance/flaskapp/views/test_transactions.py` for the split remainder auto-fill with a separator-formatted Amount, asserting the auto-filled allocation is the correct remainder and not a truncated one (depends on T034)
 
 **Checkpoint**: All five user stories functional.
 
@@ -154,16 +154,16 @@ browser code under `biweeklybudget/flaskapp/static/js/`, tests under
 
 **Purpose**: Constitution obligations — docs, version, changelog, and the full test gate.
 
-- [ ] T037 [P] Document accepted currency input formats in `docs/source/app_usage.rst`, as a subsection of the existing localization content, listing the accepted and rejected forms and noting that conventions follow `LOCALE_NAME`
-- [ ] T038 [P] Verify `grep -rn "currency_fields\|decimal_fields" biweeklybudget/flaskapp/views/` enumerates the complete FR-009 inventory from `data-model.md`, and that `grep -n parseFloat biweeklybudget/flaskapp/static/js/transactions_modal.js` returns nothing (SC-005)
-- [ ] T039 Run `tox -e py314` to completion with full output redirected to a scratchpad file; fix every failure and every pycodestyle/pyflakes finding
-- [ ] T040 Run `tox -e acceptance` to completion with full output redirected to a scratchpad file; fix every failure. A timeout is **not** a pass — raise the `pytest.ini` timeout and the tool timeout and re-run rather than narrowing the selection (constitution II) (depends on T039)
-- [ ] T041 [P] Run `tox -e migrations` and confirm it passes unchanged — this feature touches no models, so any failure here is a regression (depends on T039)
-- [ ] T042 Run `tox -e jsdoc` to regenerate `docs/source/jsdoc.custom.rst` for the new JS function and commit the regenerated file (`node` and `jsdoc` are available on this machine) (depends on T033)
-- [ ] T043 Run `tox -e docs` and confirm it builds clean, including the regenerated `docs/source/biweeklybudget.utils.rst` (depends on T037, T042)
-- [ ] T044 Bump `VERSION` in `biweeklybudget/version.py` from `1.6.2` to `1.7.0` and add the matching entry to `CHANGES.rst` in the existing format, referencing issue #323 (depends on T039, T040)
-- [ ] T045 Walk the manual verification table in [quickstart.md](./quickstart.md) against a locally running `flask rundev` instance, confirming all six Transaction-modal rows and the other-form spot checks (depends on T040)
-- [ ] T046 Update this file and [plan.md](./plan.md) to record completion status, then commit, push the branch to `origin`, and open the pull request (depends on all)
+- [X] T037 [P] Document accepted currency input formats in `docs/source/app_usage.rst`, as a subsection of the existing localization content, listing the accepted and rejected forms and noting that conventions follow `LOCALE_NAME`
+- [X] T038 [P] Verify `grep -rn "currency_fields\|decimal_fields" biweeklybudget/flaskapp/views/` enumerates the complete FR-009 inventory from `data-model.md`, and that `grep -n parseFloat biweeklybudget/flaskapp/static/js/transactions_modal.js` returns nothing (SC-005)
+- [X] T039 Run `tox -e py314` to completion with full output redirected to a scratchpad file; fix every failure and every pycodestyle/pyflakes finding
+- [X] T040 Run `tox -e acceptance` to completion with full output redirected to a scratchpad file; fix every failure. A timeout is **not** a pass — raise the `pytest.ini` timeout and the tool timeout and re-run rather than narrowing the selection (constitution II) (depends on T039)
+- [X] T041 [P] Run `tox -e migrations` and confirm it passes unchanged — this feature touches no models, so any failure here is a regression (depends on T039)
+- [X] T042 Run `tox -e jsdoc` to regenerate `docs/source/jsdoc.custom.rst` for the new JS function and commit the regenerated file (`node` and `jsdoc` are available on this machine) (depends on T033)
+- [X] T043 Run `tox -e docs` and confirm it builds clean, including the regenerated `docs/source/biweeklybudget.utils.rst` (depends on T037, T042)
+- [X] T044 Bump `VERSION` in `biweeklybudget/version.py` from `1.6.2` to `1.7.0` and add the matching entry to `CHANGES.rst` in the existing format, referencing issue #323 (depends on T039, T040)
+- [X] T045 Walk the manual verification table in [quickstart.md](./quickstart.md) against a locally running `flask rundev` instance, confirming all six Transaction-modal rows and the other-form spot checks (depends on T040)
+- [X] T046 Update this file and [plan.md](./plan.md) to record completion status, then commit, push the branch to `origin`, and open the pull request (depends on all)
 
 ---
 
@@ -247,3 +247,45 @@ and validate** before going further.
   assertions, and those failures will otherwise look like feature bugs
 - Do not weaken `strict=True` in T003 to make a test pass. Without it, Babel reads `10,00`
   as `1000` — the exact silent-corruption failure this feature exists to prevent
+
+
+---
+
+## Completion Status
+
+**All 46 tasks complete.** Suites run to completion on 2026-09-06 against
+MariaDB 10.4.7 and Chromium:
+
+| Suite | Result |
+|-------|--------|
+| `tox -e py314` (unit, pycodestyle, pyflakes) | **498 passed**, 0 failed |
+| `tox -e acceptance` (Selenium browser tests) | **577 passed**, 24 skipped, 0 failed |
+| `tox -e migrations` | **6 passed**, 0 failed (unchanged - no model changes) |
+| `tox -e docs` | build succeeded |
+| `tox -e jsdoc` | OK; `docs/source/jsdoc.custom.rst` regenerated and committed |
+| `tox -e screenshots` | OK |
+
+Notes on execution:
+
+- **T022 was a no-op.** `grep -rn 'Invalid float value\|Invalid Decimal value'`
+  found no assertions on the old message wording anywhere in the tree, so the
+  rewording in T009 broke nothing.
+- **Three parser defects were found and fixed during implementation**, none of which
+  the plan anticipated:
+  1. Babel's `parse_decimal` falls through to `Decimal()`, which accepts `1e5`,
+     `nan` and `inf`. Added an explicit character-class check so only digits and
+     the locale's two separators reach the parser.
+  2. The JS `endsWith` emulation matched when `lastIndexOf` returned `-1` and the
+     token was longer than the string, so `parse_currency('.5')` and `('5.')`
+     returned `null` - any input shorter than `'USD'` was corrupted. Fixed with a
+     length guard.
+  3. The JS parser rejected `.5`, which the server accepts. The client must never
+     be stricter than the server or it blocks submissions the server would allow.
+- **One test-isolation bug was found by the full suite**, not by the targeted runs:
+  `TestCurrencyNormalizationDoesNotChangeExistingBehavior` mutates the database but
+  originally lacked the `class_refresh_db` fixture, so a transaction it created
+  leaked into `test_fuel.py` and broke a count assertion there. Fixed by adding the
+  fixture.
+- `tox -e screenshots` regenerates every documentation PNG. Those diffs come from
+  the local Chromium's rendering rather than from this change, so they were reverted;
+  screenshots belong to the release checklist, not to this feature.


### PR DESCRIPTION
Fixes #323.

## The two defects

**1. Thousands separators produced a 500.** `FormHandlerView.post()` wrapped `submit()` in a `try`/`except` but called `validate()` unguarded, and `TransactionFormHandler.validate()` calls `Decimal(data['amount'])` directly — so `Decimal('1,234.56')` raised `InvalidOperation` straight out to Flask. Six other validators had the same shape with bare `float()`.

**2. Bare integers were rejected.** `FormHandlerView._validate_float()` asserted `data[key].startswith('%s' % float(data[key]))`, and `'123'.startswith('123.0')` is `False`, so `123` had to be typed as `123.0`.

## The fix

The issue asks for normalization "in as few places as possible using specific reused functions/methods". There were ~30 scattered `Decimal()`/`float()` conversions across `validate()` and `submit()` in 13 form handlers; this collapses them to **two functions and one interception point**:

- **`biweeklybudget.utils.parse_currency()`** and `CurrencyParseError`, placed next to the existing `fmt_currency()`. Wraps `babel.numbers.parse_decimal(..., strict=True)` and returns an exact `Decimal`. Babel was already a direct dependency and already supplied the formatting counterpart, so **no new dependency**.
- **`parse_currency()` in `static/js/custom.js`**, next to its own `fmt_currency()`, replacing the four `parseFloat()` calls in `transactions_modal.js`. This matters more than it looks: `parseFloat('1,234.56')` is `1`, so budget-split validation used to report a sum mismatch and disable Save — the server fix alone would have been unreachable in that flow.
- **`FormHandlerView`** gains `currency_fields` / `decimal_fields` declarations and a `normalize_currency()` hook that runs *before* `validate()`. Every existing downstream conversion keeps working untouched because the value is already canonical by then, and the complete set of currency fields is now greppable.

`validate()` also gets the same `try`/`except` `submit()` has always had, so no conversion anywhere can produce a 500 again.

## What is accepted, and what is deliberately not

Accepted (`en_US`/`USD`): bare integers; `,` or space thousands separators (including Unicode spaces); a leading or trailing currency symbol or ISO code; a leading `+`/`-`; parentheses for negative; surrounding whitespace — and any combination.

**`strict=True` is load-bearing, not incidental.** Without it Babel reads `10,00` as `1000`, `1,234,` as `1234` and `,123` as `123`. Silently turning a typo into a plausible number is the worst thing this code could do to a ledger, so ambiguously grouped values are rejected with a field-level error instead. In the same spirit, spaces are rewritten *to* the locale's group separator rather than deleted, so `1 234.56` parses but `1 2 3` does not.

Locale conventions come from `LOCALE_NAME`/`CURRENCY_CODE` on both sides, so adding a locale is a settings change; `de_DE` is covered by tests (`1.234,56` → 1234.56, `1,234.56` → error).

## Defects found while building it

Worth flagging, since none were anticipated by the plan:

1. Babel's `parse_decimal` falls through to `Decimal()`, so it accepted `1e5`, `nan` and `inf`. Added an explicit character-class check.
2. The JS `endsWith` emulation matched when `lastIndexOf` returned `-1` and the token was longer than the string — so **any input shorter than `'USD'`** was corrupted, including `.5` and `5.`. Fixed with a length guard.
3. The JS parser rejected `.5`, which the server accepts. The client must never be *stricter* than the server, or it blocks submissions the server would have allowed.

A test-isolation bug also surfaced only in the full suite: a new DB-mutating test class lacked `class_refresh_db`, leaking a transaction into `test_fuel.py`.

## Testing

Per the issue's request for "actual browser tests":

- **92 unit tests** over the accept/reject matrix, including locale independence and a no-float-rounding assertion.
- **21 unit tests** for the normalization hook.
- **64 Selenium acceptance tests** — the Transaction modal (comma, bare integer, symbol, spaces, parentheses, malformed, and budget splits exercising the client-side parser), plus every other currency input in the app.

All suites run to completion and pass:

| Suite | Result |
|-------|--------|
| `tox -e py314` (unit + pycodestyle + pyflakes) | 498 passed, 0 failed |
| `tox -e acceptance` | 577 passed, 24 skipped, 0 failed |
| `tox -e migrations` | 6 passed (unchanged — no model changes) |
| `tox -e docs` / `tox -e jsdoc` / `tox -e screenshots` | build clean |

Also verified by hand against a running `flask rundev`: `1,234.56` + sales tax `89` saves as $1,234.56/$89.00, and `10,00` shows `Invalid amount: "10,00"` on the Amount field with nothing saved and no 500.

## Notes

- **No schema change**, so no Alembic migration (constitution III does not apply).
- Version bumped 1.6.2 → **1.7.0** with a matching `CHANGES.rst` entry.
- Accepted input formats documented in `docs/source/app_usage.rst`; `jsdoc.custom.rst` regenerated.
- `tox -e screenshots` regenerates every documentation PNG; those diffs came from the local Chromium's rendering rather than from this change, so they were reverted — screenshots belong to the release checklist.
- Spec Kit artifacts for this feature are under `specs/20260906-155913-currency-input-normalization/`.
- Fuel Log `gallons`/`reported_mpg` are not currency but shared the defective validation helper, so they are fixed too (with "number" rather than "amount" wording).

### Constitution deviation

The constitution requires human approval at each milestone boundary. This work was dispatched to run the full Spec Kit lifecycle through to a PR without a human in the loop, so that approval was not obtained interactively. It is recorded in the plan's Complexity Tracking, every artifact is committed for review, the full test gate was still enforced, and **this PR is the approval gate**.

## Pull Request Checklist

- [x] pep8 compliant with the exceptions in `pytest.ini`
- [x] New code covered by valid tests (unit + browser)
- [x] Complete, correctly-formatted documentation for all new functions
- [x] Documentation rebuilt with `tox -e docs`
- [x] Module-level loggers used
- [x] Commit messages reference the issue number
- [x] Git history intact; nothing squashed or rewritten

### Contributor License Agreement

By submitting this work for inclusion in biweeklybudget, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it) is being made under the same license as the biweeklybudget project (the Affero GPL v3, or any subsequent version of that license if adopted by biweeklybudget).
* My contribution may perpetually be included in and distributed with biweeklybudget; submitting this pull request grants a perpetual, global, unlimited license for it to be used and distributed under the terms of biweeklybudget's license.
* I have the legal power and rights to agree to these terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137DMFdfr8SjV27o2E9bFDK
