### PR TITLE
Issue #261 - /plaid-update returns HTTP 500 when any Plaid Item fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+* `Issue #261 <https://github.com/jantman/biweeklybudget/issues/261>`_ - ``/plaid-update`` now returns HTTP 500 instead of 200 when any Plaid Item fails to update, in all response formats. The response body is unchanged.
+
+  * Scripts calling the endpoint (for example with ``curl --fail``) will now see partial failures as errors.
+
 * Change the release process: changes accumulate under this ``Unreleased`` heading, and the version is only incremented when a release is cut, following `Semantic Versioning 2.0.0 <https://semver.org/spec/v2.0.0.html>`_. Changelog entries should be concise. The development documentation, ``CLAUDE.md``, project constitution, and pull request template are updated to match.
 
   * Reset ``version.py`` to ``1.6.0``, the most recent release. The changes below were previously listed under versions 1.6.1 through 1.12.1, which were never released, and have been rewritten more concisely.

--- a/biweeklybudget/flaskapp/views/plaid.py
+++ b/biweeklybudget/flaskapp/views/plaid.py
@@ -256,6 +256,10 @@ class PlaidUpdate(MethodView):
         text human-readable summary of the update operation.
       * Otherwise, return a templated view of the update operation results, as
         would be returned to a browser.
+
+      In all three forms, the HTTP status is 200 if every Plaid Item was
+      updated successfully (or there were none to update) and 500 if one or
+      more Items failed to update; the response body is the same either way.
     """
 
     def post(self):
@@ -304,6 +308,9 @@ class PlaidUpdate(MethodView):
         :type ids: str
         :param num_days: number of days to retrieve transactions for; default 30
         :type num_days: int
+        :return: the update results in the form requested by the
+          ``Accept`` header, with HTTP status 200 if every Item was
+          updated successfully or 500 if any Item failed to update
         """
         logger.info(
             'Handle Plaid Update request; item_ids=%s num_days=%d',
@@ -318,6 +325,8 @@ class PlaidUpdate(MethodView):
                 db_session.query(PlaidItem).get(x) for x in ids
             ]
         results = updater.update(items=items, days=num_days)
+        # any failed Item makes the whole update a failure (issue #261)
+        status = 200 if all(r.success for r in results) else 500
         if request.headers.get('accept') == 'text/plain':
             s = ''
             num_updated = 0
@@ -336,9 +345,9 @@ class PlaidUpdate(MethodView):
                      f'updated, {r.added} added (stmts: {r.stmt_ids})\n'
             s += f'TOTAL: {num_updated} updated, {num_added} added, ' \
                  f'{num_failed} account(s) failed'
-            return s
+            return s, status
         if request.headers.get('accept') == 'application/json':
-            return jsonify([x.as_dict for x in results])
+            return jsonify([x.as_dict for x in results]), status
         # have to do this here in python and iterate twice, because of
         # https://github.com/pallets/jinja/issues/641
         num_updated = 0
@@ -355,7 +364,7 @@ class PlaidUpdate(MethodView):
             num_added=num_added,
             num_updated=num_updated,
             num_failed=num_failed
-        )
+        ), status
 
     def _form(self):
         items: List[PlaidItem] = db_session.query(PlaidItem).all()

--- a/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
+++ b/biweeklybudget/tests/unit/flaskapp/views/test_plaid.py
@@ -975,7 +975,7 @@ class TestPlaidUpdate:
             mocks['jsonify'].return_value = mock_json
             with patch(f'{pbm}.request', mock_req):
                 res = self.cls._update('ALL')
-        assert res == rendered
+        assert res == (rendered, 500)
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
             call.available_items(),
@@ -1050,7 +1050,7 @@ class TestPlaidUpdate:
             with patch(f'{pbm}.request', mock_req):
                 with patch(f'{pbm}.db_session', mock_db):
                     res = self.cls._update('Item1')
-        assert res == mock_json
+        assert res == (mock_json, 200)
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
             call().update(items=[items[0]], days=30)
@@ -1132,9 +1132,12 @@ class TestPlaidUpdate:
             with patch(f'{pbm}.request', mock_req):
                 with patch(f'{pbm}.db_session', mock_db):
                     res = self.cls._update('Item1')
-        assert res == "InstName1 (Item1): 1 updated, 2 added (stmts: SID1," \
-                      "SID2,SID3)\nInstName2 (Item2): Failed: MyException\n" \
-                      "TOTAL: 1 updated, 2 added, 1 account(s) failed"
+        assert res == (
+            "InstName1 (Item1): 1 updated, 2 added (stmts: SID1,"
+            "SID2,SID3)\nInstName2 (Item2): Failed: MyException\n"
+            "TOTAL: 1 updated, 2 added, 1 account(s) failed",
+            500
+        )
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
             call().update(items=[items[0]], days=30)
@@ -1214,9 +1217,12 @@ class TestPlaidUpdate:
             with patch(f'{pbm}.request', mock_req):
                 with patch(f'{pbm}.db_session', mock_db):
                     res = self.cls._update('Item1', num_days=12)
-        assert res == "InstName1 (Item1): 1 updated, 2 added (stmts: SID1," \
-                      "SID2,SID3)\nInstName2 (Item2): Failed: MyException\n" \
-                      "TOTAL: 1 updated, 2 added, 1 account(s) failed"
+        assert res == (
+            "InstName1 (Item1): 1 updated, 2 added (stmts: SID1,"
+            "SID2,SID3)\nInstName2 (Item2): Failed: MyException\n"
+            "TOTAL: 1 updated, 2 added, 1 account(s) failed",
+            500
+        )
         assert mocks['PlaidUpdater'].mock_calls == [
             call(),
             call().update(items=[items[0]], days=12)
@@ -1230,6 +1236,95 @@ class TestPlaidUpdate:
             call.query(PlaidItem),
             call.query().get('Item1'),
         ]
+
+    def _update_with_results(self, accept, result):
+        """
+        Call ``_update('Item1')`` with the given ``Accept`` header (or none, if
+        ``accept`` is None) and with :py:meth:`~.PlaidUpdater.update`
+        returning ``result``. Return the response and the patched mocks.
+        """
+        mock_req = Mock(headers={} if accept is None else {'accept': accept})
+        mock_updater = Mock()
+        mock_updater.update.return_value = result
+        with patch.multiple(
+            pbm,
+            PlaidUpdater=DEFAULT,
+            render_template=DEFAULT,
+            jsonify=DEFAULT
+        ) as mocks:
+            mocks['PlaidUpdater'].return_value = mock_updater
+            with patch(f'{pbm}.request', mock_req):
+                with patch(f'{pbm}.db_session'):
+                    res = self.cls._update('Item1')
+        return res, mocks
+
+    def test_update_json_failure(self):
+        result = [
+            Mock(success=True, updated=1, added=2, as_dict='res1'),
+            Mock(success=False, updated=0, added=0, as_dict='res2')
+        ]
+        res, mocks = self._update_with_results('application/json', result)
+        assert res == (mocks['jsonify'].return_value, 500)
+        assert mocks['jsonify'].mock_calls == [call(['res1', 'res2'])]
+        assert mocks['render_template'].mock_calls == []
+
+    def test_update_all_failed(self):
+        items = [
+            Mock(spec_set=PlaidItem, item_id='Item1',
+                 institution_name='InstName1'),
+            Mock(spec_set=PlaidItem, item_id='Item2',
+                 institution_name='InstName2')
+        ]
+        result = [
+            Mock(success=False, updated=0, added=0, item=items[0],
+                 exc='Exc1'),
+            Mock(success=False, updated=0, added=0, item=items[1],
+                 exc='Exc2')
+        ]
+        res, mocks = self._update_with_results('text/plain', result)
+        assert res == (
+            "InstName1 (Item1): Failed: Exc1\n"
+            "InstName2 (Item2): Failed: Exc2\n"
+            "TOTAL: 0 updated, 0 added, 2 account(s) failed",
+            500
+        )
+        assert mocks['render_template'].mock_calls == []
+        assert mocks['jsonify'].mock_calls == []
+
+    def test_update_template_all_success(self):
+        result = [
+            Mock(success=True, updated=1, added=2, as_dict='res1'),
+            Mock(success=True, updated=3, added=4, as_dict='res2')
+        ]
+        res, mocks = self._update_with_results(None, result)
+        assert res == (mocks['render_template'].return_value, 200)
+        assert mocks['render_template'].mock_calls == [call(
+            'plaid_result.html',
+            results=result,
+            num_added=6,
+            num_updated=4,
+            num_failed=0
+        )]
+        assert mocks['jsonify'].mock_calls == []
+
+    def test_update_plain_all_success(self):
+        item = Mock(
+            spec_set=PlaidItem, item_id='Item1', institution_name='InstName1'
+        )
+        result = [
+            Mock(success=True, updated=1, added=2, stmt_ids=[5], item=item)
+        ]
+        res, mocks = self._update_with_results('text/plain', result)
+        assert res == (
+            "InstName1 (Item1): 1 updated, 2 added (stmts: [5])\n"
+            "TOTAL: 1 updated, 2 added, 0 account(s) failed",
+            200
+        )
+
+    def test_update_no_items(self):
+        res, mocks = self._update_with_results('application/json', [])
+        assert res == (mocks['jsonify'].return_value, 200)
+        assert mocks['jsonify'].mock_calls == [call([])]
 
 
 class TestPlaidLinkToken:

--- a/docs/source/http_api.rst
+++ b/docs/source/http_api.rst
@@ -801,7 +801,7 @@ Create a new :py:class:`~.Vehicle` or update an existing one. Handled by :py:cla
 Plaid
 -----
 
-Plaid transaction updating is documented in detail at :ref:`plaid.update-api`. In summary, the ``/plaid-update`` endpoint accepts ``item_ids`` (a comma-separated list of :py:class:`~.PlaidItem` IDs or ``ALL``) and an optional ``num_days`` parameter, and can return JSON (``Accept: application/json``) or plain text (``Accept: text/plain``) responses.
+Plaid transaction updating is documented in detail at :ref:`plaid.update-api`. In summary, the ``/plaid-update`` endpoint accepts ``item_ids`` (a comma-separated list of :py:class:`~.PlaidItem` IDs or ``ALL``) and an optional ``num_days`` parameter, and can return JSON (``Accept: application/json``) or plain text (``Accept: text/plain``) responses. It returns HTTP 200 if every Item updated successfully, and HTTP 500 (with the same per-Item results in the body) if any Item failed.
 
 .. _http_api.utility:
 

--- a/docs/source/plaid.rst
+++ b/docs/source/plaid.rst
@@ -65,6 +65,8 @@ Transactions can be updated via a simple API at the same ``/plaid-update`` endpo
 
 In short, the endpoint takes a POST or GET request that specifies an ``item_ids`` parameter as a string comma-separated list of :py:class:`~.PlaidItem` IDs to update, or the special string ``ALL`` to update all Items. Optionally, you can specify a ``num_days`` parameter to retrieve transactions for something other than the last 30 days. The response is either JSON if the ``Accept`` header is set to ``application/json`` or human-readable plain text if set to ``text/plain`` (if set to any other value, it will return the full HTML that would be sent to the browser).
 
+The HTTP status code reports whether the update succeeded, in all three response formats: ``200`` if every requested Item was updated successfully, or ``500`` if one or more Items failed to update. In both cases the response body reports the result for every Item, including the error for any that failed. A POST request without ``item_ids`` returns ``400``. Scripts can therefore detect a failed update from the status code alone, such as with ``curl --fail``.
+
 The following examples assume that biweeklybudget is available at ``http://127.0.0.1:8080``
 
 To update transactions for all Plaid Items via a GET request and return human-readable text:

--- a/specs/20260911-160541-plaid-update-failure-status/checklists/requirements.md
+++ b/specs/20260911-160541-plaid-update-failure-status/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Plaid Update Reports Failure In Its Status Code
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The feature is an HTTP endpoint's status code, so the spec names the endpoint
+  (`/plaid-update`) and HTTP status codes. These are the user-facing contract under
+  change, not implementation details; the spec says nothing about how the change is made.
+- The specific failure status (HTTP 500) was chosen as a reasonable default rather than
+  raised as a clarification; the rationale is recorded under Assumptions.
+- All items pass on the first validation pass.

--- a/specs/20260911-160541-plaid-update-failure-status/contracts/plaid-update.md
+++ b/specs/20260911-160541-plaid-update-failure-status/contracts/plaid-update.md
@@ -1,0 +1,20 @@
+# Contract: `/plaid-update` status codes
+
+Endpoint: `GET` or `POST /plaid-update`. Parameters are unchanged (`item_ids`, optional
+`num_days`); see `docs/source/plaid.rst`.
+
+| Request | Outcome | Status | Body |
+|---------|---------|--------|------|
+| GET, no `item_ids` | update form | 200 | form HTML (unchanged) |
+| POST, no `item_ids` (query or form) | rejected | 400 | `{"success": false, "message": "Missing parameter: item_ids"}` (unchanged) |
+| GET/POST with `item_ids`, every Item succeeds | update ran | **200** | results in the requested format (unchanged) |
+| GET/POST with `item_ids`, no Items to update | update ran | **200** | empty results (unchanged) |
+| GET/POST with `item_ids`, one or more Items fail | update ran, incomplete | **500** | full results in the requested format, including every failed Item's error (unchanged) |
+
+The result formats, chosen by the `Accept` header, are all unchanged:
+
+- `text/plain`: one line per Item, then `TOTAL: N updated, N added, N account(s) failed`.
+- `application/json`: a list of `{"item_id", "success", "exception", "statement_ids", "added", "updated"}`.
+- anything else: the HTML results page.
+
+The status rule is identical for all three formats and for both methods.

--- a/specs/20260911-160541-plaid-update-failure-status/data-model.md
+++ b/specs/20260911-160541-plaid-update-failure-status/data-model.md
@@ -1,0 +1,25 @@
+# Data Model: Plaid Update Reports Failure In Its Status Code
+
+No persistent data changes: no model, table, column, or migration.
+
+## PlaidUpdateResult (existing, unchanged)
+
+Defined in `biweeklybudget/plaid_updater.py`. One per requested Plaid Item, returned by
+`PlaidUpdater.update()`.
+
+| Field | Meaning |
+|-------|---------|
+| `item` | the `PlaidItem` updated |
+| `success` | `True` if the Item updated without error |
+| `updated` / `added` | transaction counts (0 on failure) |
+| `exc` | the exception caught on failure, else `None` |
+| `stmt_ids` | IDs of statements created (`None` on failure) |
+
+## Derived value: response status
+
+```text
+status = 500  if any result has success == False
+       = 200  otherwise (including when there are no results)
+```
+
+Computed per request in `PlaidUpdate._update()` and never stored.

--- a/specs/20260911-160541-plaid-update-failure-status/plan.md
+++ b/specs/20260911-160541-plaid-update-failure-status/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Plaid Update Reports Failure In Its Status Code
+
+**Branch**: `robot-army/issue-261-plaid-update-endpoint-needs-to-return` | **Date**: 2026-09-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/20260911-160541-plaid-update-failure-status/spec.md`
+
+## Summary
+
+`PlaidUpdate._update()` in `biweeklybudget/flaskapp/views/plaid.py` already has the list
+of per-Item `PlaidUpdateResult`s before it builds any of its three responses. It will
+compute one status code from that list: HTTP 500 if any result has `success` false,
+otherwise HTTP 200. Each of the three return statements (plain text, JSON, HTML template)
+then returns `(body, status)` instead of a bare body. Bodies are untouched.
+
+Unit tests in `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py` pin the status
+for each format in both the failing and the all-successful case, plus the empty-result
+case. The Plaid documentation page and the HTTP API summary gain a sentence on status
+codes, and `CHANGES.rst` gets one `Unreleased` entry.
+
+## Technical Context
+
+**Language/Version**: Python 3.14 (3.14.7)
+
+**Primary Dependencies**: Flask 3.1.3 / Werkzeug 3.1.8. A Flask view can return a
+`(body, status)` tuple for any body type the view already returns (`str`, a `Response`
+from `jsonify`, or rendered template text). No new dependency.
+
+**Storage**: MariaDB, unchanged. No model, schema, or migration change.
+
+**Testing**: pytest. Unit tests (`tox -e py314`) cover the view with mocks, following the
+existing `TestPlaidUpdate` pattern. The full unit and acceptance suites must pass
+(Constitution II). `docs` must build (Constitution IV).
+
+**Target Platform**: Linux; the Flask app served locally or in Docker.
+
+**Project Type**: Flask/SQLAlchemy web application. One view method changes.
+
+**Performance Goals**: None. One pass over an already-built list of a handful of results.
+
+**Constraints**: Response bodies MUST NOT change (spec FR-004). No change to
+`PlaidUpdater` or `PlaidUpdateResult`.
+
+**Scale/Scope**: One method (~5 changed lines), its unit tests, two doc pages, one
+changelog entry.
+
+## Constitution Check
+
+*Constitution v2.1.1. Gate evaluated before Phase 0 and re-evaluated after Phase 1.*
+
+| Principle | Assessment | Status |
+|-----------|-----------|--------|
+| **I. Spec-Driven Change** (NON-NEGOTIABLE) | Spec written and validated, then this plan, then tasks, all before code. Work stays on the feature branch `robot-army/issue-261-plaid-update-endpoint-needs-to-return`. The change is small enough to be a **single milestone (M1)**, so there is no inter-milestone boundary to cross. The maintainer's human approval is taken at the pull request, before merge. | PASS |
+| **II. The Test Gate** (NON-NEGOTIABLE) | New and changed unit tests pin the status code for every response format in the failing, all-successful, and empty cases (spec SC-001/SC-002). The complete unit and acceptance suites MUST run to completion and pass before the feature is declared done. The `plaid` suite needs Plaid sandbox credentials and runs in CI. The `migrations` and `docker` suites are not engaged (no schema or packaging change) but still run in CI. Timeouts get raised and re-run, never narrowed. Touched code stays pycodestyle/pyflakes-clean. | PASS |
+| **III. Reversible Migrations** | No change under `biweeklybudget/models/`; not engaged. | N/A |
+| **IV. Documentation Is Part Of The Change** | `docs/source/plaid.rst` (update API section) and `docs/source/http_api.rst` (summary) are updated in the same change, along with the `PlaidUpdate` docstring that Sphinx renders. The `docs` environment must build clean. `README.rst` and `CLAUDE.md` don't describe this endpoint's responses, so they need no change. | PASS |
+| **V. Escalate Instead Of Guessing** | The issue asks only for "non-200". Choosing HTTP 500, and applying it to the browser view too, are judgement calls with obvious defaults. They are recorded with reasoning in research R1 and R2 and surfaced in the PR for the maintainer to overrule, not guessed silently. | PASS |
+| **VI. Changelog Every Change; Release Only On Request** | One concise `CHANGES.rst` bullet under `Unreleased`, led by the issue link, noting the behaviour change for API callers. `version.py` is not touched; no tag. No new Python files, so no new copyright headers. | PASS |
+| **Tech constraints** | No new dependency, no license question, no secrets, no security-posture change, no financial-calculation code touched. Acceptance tests keep using only the dedicated test database. | PASS |
+
+**Result: no violations. The Complexity Tracking table is therefore omitted.**
+
+Post-Phase-1 re-evaluation: the design adds no module, abstraction, or dependency. It
+is a local change to one method's return values, and the Constitution Check still passes.
+
+## Design
+
+```text
+results = updater.update(items=items, days=num_days)
+status  = 200 if all(r.success for r in results) else 500   # all([]) is True → 200
+text/plain        → return s, status
+application/json  → return jsonify([...]), status
+otherwise (HTML)  → return render_template(...), status
+```
+
+- `all()` over an empty list is `True`, so "no Items updated" is 200 with no special case
+  (spec edge case).
+- The status is computed once, before the format branch, so the three formats can't
+  drift apart (spec FR-003).
+- GET and POST both reach `_update()`, so both are covered (FR-003).
+- The request handlers' existing 400 for a POST missing `item_ids`, and the GET form view,
+  are outside `_update()` and unchanged.
+
+### Project Structure
+
+Documentation for this feature:
+
+```text
+specs/20260911-160541-plaid-update-failure-status/
+├── spec.md
+├── plan.md              # this file
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   └── plaid-update.md  # Phase 1: the endpoint's status-code contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2, written by /speckit-tasks
+```
+
+Repository files this change touches:
+
+```text
+biweeklybudget/
+├── flaskapp/views/plaid.py                      # PlaidUpdate._update + class docstring
+└── tests/unit/flaskapp/views/test_plaid.py      # TestPlaidUpdate status assertions + new cases
+docs/source/plaid.rst                            # status codes in the update API section
+docs/source/http_api.rst                         # status codes in the summary
+CHANGES.rst                                      # Unreleased entry
+```
+
+**Structure Decision**: the existing layout is kept. No new file outside `specs/`.
+
+## Milestones
+
+- **M1 — Status code, tests, and docs.** Change `_update()` and its docstring. Update
+  the three existing `_update` unit tests to assert the status, and add tests for the
+  cases they don't cover. Update the two doc pages and `CHANGES.rst`. Run the Test Gate
+  (unit, acceptance, docs), record the results in the spec artifacts, then commit, push,
+  and open the PR.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| An existing caller treats any non-200 as fatal and now aborts on a partial failure. | That is the requested behaviour. The changelog entry calls it out so operators can adjust. |
+| Returning a tuple changes the body or its content type. | Flask applies the status to the same response it would have built. The unit tests assert the exact body object and status, and the acceptance browser flow (`test_plaidlink.py::test_17`) still renders the failed-results page. Research R3 covers why that test is unaffected. |
+| A failing-update response is mistaken for an unhandled server crash. | The body still carries the full per-Item report, and the docs state that 500 with a results body means one or more Items failed. |

--- a/specs/20260911-160541-plaid-update-failure-status/plan.md
+++ b/specs/20260911-160541-plaid-update-failure-status/plan.md
@@ -119,6 +119,20 @@ CHANGES.rst                                      # Unreleased entry
   (unit, acceptance, docs), record the results in the spec artifacts, then commit, push,
   and open the PR.
 
+## Test Gate Results (M1, 2026-09-11)
+
+Run locally against MariaDB 10.4.7 (the CI image), Python 3.14.7:
+
+| Suite | Result |
+|-------|--------|
+| `tox -e py314` (unit + pycodestyle + pyflakes) | 889 passed, 5 skipped, 0 failed. `views/plaid.py` 100% line and branch coverage |
+| `tox -e acceptance` | 793 passed, 24 skipped, 0 failed (17m03s) |
+| `tox -e docs` | builds (exit 0). No broken links, and no new warnings. The `_update`/`_form` cross-reference warnings in the `PlaidUpdate` docstrings predate this change |
+
+The new and changed `TestPlaidUpdate` assertions were first run against the unchanged
+view and failed (9 tests; the other 19 in the file passed), then all passed once T003 was
+in. `migrations`, `docker`, and `plaid` are not engaged and run in CI.
+
 ## Risks
 
 | Risk | Mitigation |

--- a/specs/20260911-160541-plaid-update-failure-status/quickstart.md
+++ b/specs/20260911-160541-plaid-update-failure-status/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart: validating the `/plaid-update` status code
+
+## Automated
+
+Unit tests (need the MariaDB test container described in `CLAUDE.md`):
+
+```bash
+tox -e py314 -- biweeklybudget/tests/unit/flaskapp/views/test_plaid.py -k TestPlaidUpdate
+```
+
+Expected: every `TestPlaidUpdate` test passes, including the status-code cases for each
+format (failing → 500, all-successful → 200, no results → 200).
+
+The full Test Gate (Constitution II): `tox -e py314`, `tox -e acceptance`, `tox -e docs`,
+all run to completion and passing.
+
+## Manual, against a running instance with Plaid Items
+
+With the app at `http://127.0.0.1:8080` (see `docs/source/plaid.rst`):
+
+1. All Items healthy:
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' -H 'Accept: text/plain' \
+     'http://127.0.0.1:8080/plaid-update?item_ids=ALL'
+   ```
+
+   Expected: `200`.
+
+2. At least one Item failing (in the Plaid sandbox, `sandbox_item_reset_login` puts an
+   Item into `ITEM_LOGIN_REQUIRED`, as `test_plaidlink.py::test_16` does):
+
+   ```bash
+   curl --fail -H 'Accept: text/plain' 'http://127.0.0.1:8080/plaid-update?item_ids=ALL'; echo "exit=$?"
+   ```
+
+   Expected: `curl` exits 22 (HTTP error). Without `--fail`, the body still shows the
+   failing Item's line and `1 account(s) failed`.
+
+3. The same with `-H 'Accept: application/json'` returns 500 and a JSON list with
+   `"success": false` for the failing Item.
+
+4. In a browser, updating with a failing Item selected still shows the results page
+   listing the failure. The browser's network panel shows status 500.

--- a/specs/20260911-160541-plaid-update-failure-status/research.md
+++ b/specs/20260911-160541-plaid-update-failure-status/research.md
@@ -1,0 +1,58 @@
+# Research: Plaid Update Reports Failure In Its Status Code
+
+## R1 — Which non-200 status
+
+**Decision**: HTTP 500 Internal Server Error when one or more Items fail.
+
+**Rationale**: The issue asks for "non-200". The consumers that motivate it (`curl
+--fail`, cron wrappers, monitoring checks) treat any 4xx/5xx as failure, so the code only
+has to be an error code that honestly describes the situation. A failed Item means the
+server could not complete the requested work, and nothing is wrong with the request, which
+rules out 4xx. 500 is the generic code for that, and it's accurate whatever the cause:
+`PlaidUpdater._do_item()` catches *every* exception, whether an expired Plaid login, a
+Plaid API error, or a local database error.
+
+**Alternatives considered**:
+
+- **207 Multi-Status**: made for per-item results, but it is a 2xx. `curl --fail` and most
+  monitors would still report success, which defeats the issue.
+- **502 Bad Gateway**: says the fault is upstream. Often true here (Plaid), but not
+  always, since local errors are caught the same way.
+- **Different codes for partial vs. total failure**: adds a distinction no identified
+  caller needs. The body already reports exactly which Items failed.
+
+## R2 — Which response formats get the status
+
+**Decision**: All three (plain text, JSON, browser HTML), from one status computed before
+the format branch.
+
+**Rationale**: The issue names the endpoint, not a format. Browsers render a 500 page's
+body normally, so the interactive results page looks the same, and one rule is easier
+to document and test than per-format rules.
+
+**Alternatives considered**: API formats only (text/JSON), leaving HTML at 200. Rejected
+because it makes the status depend on the `Accept` header for no user benefit.
+
+## R3 — Effect on existing tests
+
+- **Unit** (`tests/unit/flaskapp/views/test_plaid.py::TestPlaidUpdate`): the existing
+  `_update` tests assert `res == <body>`. With a tuple return they must assert
+  `res == (<body>, <status>)`. `test_update_template` and the two `test_update_plain*`
+  tests contain a failed result (→ 500). `test_update_json` is all-successful (→ 200).
+  The `get`/`post` tests mock `_update` and pass its return value through, so they are
+  unaffected.
+- **Acceptance**: the helper (`tests/acceptance_helpers.py`) never inspects HTTP status,
+  and Selenium cannot observe it. `test_plaidlink.py::test_17_try_update_transactions_expect_error`
+  drives a failing update through the browser form and asserts the rendered table, which
+  is unchanged. That class is also marked `plaid` (it runs only in the `plaid` tox
+  environment, which needs sandbox credentials) and is `xfail` only when `CI == 'true'`,
+  because the Plaid Link flow fails in headless Chrome.
+- **Unit test for `PlaidUpdater`** (`tests/unit/test_plaid_updater.py`): unaffected; the
+  updater doesn't change.
+
+## R4 — Flask tuple returns
+
+Flask 3.1 accepts `(body, status)` from a view, where the body is a `str`, a `Response`
+(as returned by `jsonify`), or template output. The status is applied to the response it
+would have built anyway, so the body and content type don't change. No need for
+`make_response`.

--- a/specs/20260911-160541-plaid-update-failure-status/spec.md
+++ b/specs/20260911-160541-plaid-update-failure-status/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-09-11
 
-**Status**: Draft
+**Status**: Complete
 
 **Input**: GitHub issue [#261](https://github.com/jantman/biweeklybudget/issues/261) — "/plaid-update endpoint needs to return non-200 if any failed"
 

--- a/specs/20260911-160541-plaid-update-failure-status/spec.md
+++ b/specs/20260911-160541-plaid-update-failure-status/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Plaid Update Reports Failure In Its Status Code
+
+**Feature Branch**: `robot-army/issue-261-plaid-update-endpoint-needs-to-return`
+
+**Created**: 2026-09-11
+
+**Status**: Draft
+
+**Input**: GitHub issue [#261](https://github.com/jantman/biweeklybudget/issues/261) — "/plaid-update endpoint needs to return non-200 if any failed"
+
+## Context
+
+The `/plaid-update` endpoint downloads transactions from Plaid for one or more Plaid
+Items and reports a result for each. It is used both interactively from the browser and
+unattended, for example from a scheduled `curl` job, where the documented plain-text and
+JSON responses are the intended interface.
+
+Today, when updating an Item fails (an expired login, a Plaid API error, or any other
+error), the failure is recorded in that Item's result and the endpoint still answers
+with HTTP 200 OK. A script or scheduler that checks the status code, which is the
+conventional and often the only check (`curl --fail`, cron wrappers, monitoring), sees
+success and never alerts anyone. Failed updates therefore go unnoticed until someone
+reads the output, and transactions quietly stop arriving.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An unattended update that fails is detected (Priority: P1)
+
+The maintainer runs a Plaid update for all Items from a scheduled job. One Item's bank
+login has expired, so its update fails while the others succeed. The job sees a non-success
+status code, treats the run as failed, and alerts the maintainer, who can read the response
+body to see which Item failed and why.
+
+**Why this priority**: This is the whole of the issue. Without it, automated updates fail
+silently.
+
+**Independent Test**: Request an update of several Items where at least one fails,
+using each response format (plain text, JSON, and browser HTML). Confirm the status code
+is not 200 and the body still lists every Item's result, including the failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** an update of several Items in which exactly one fails, **When** the update is
+   requested with `Accept: text/plain`, **Then** the response status is HTTP 500 and the
+   body is the same human-readable summary as before, including the failed Item's error
+   and the count of failed accounts.
+2. **Given** the same partially failing update, **When** it is requested with
+   `Accept: application/json`, **Then** the response status is HTTP 500 and the body is
+   the same JSON list of per-Item results as before, with the failed Item's `success`
+   set to false.
+3. **Given** the same partially failing update, **When** it is requested from a browser
+   (any other `Accept` value), **Then** the response status is HTTP 500 and the results
+   page renders as before, showing the failed Item.
+4. **Given** an update in which every Item fails, **When** it is requested in any of the
+   three formats, **Then** the response status is HTTP 500 and the body reports every
+   failure.
+
+---
+
+### User Story 2 - A fully successful update still reports success (Priority: P1)
+
+The maintainer's scheduled update runs and every Item updates successfully. The job sees
+HTTP 200 and does not alert.
+
+**Why this priority**: Equally essential. An endpoint that reported failure on success
+would train the maintainer to ignore its alerts, and the change would be worse than useless.
+
+**Independent Test**: Request an update in which every Item succeeds, in each response
+format, and confirm the status is HTTP 200 and the body is unchanged from today.
+
+**Acceptance Scenarios**:
+
+1. **Given** an update in which every Item succeeds, **When** it is requested in any of
+   the three formats, **Then** the response status is HTTP 200 and the body is unchanged
+   from current behaviour.
+
+### Edge Cases
+
+- **No Items to update** (for example `item_ids=ALL` with no Plaid Items configured):
+  nothing failed, so the response is HTTP 200 with an empty result set, as today.
+- **Missing `item_ids` on a POST**: unchanged, and still answered with HTTP 400.
+- **A requested Item ID that does not exist**: out of scope. That request already fails
+  with an HTTP 500 error before any results are produced, and this feature does not
+  change it.
+- **The form view** (GET with no `item_ids`): unaffected. No update happens, so the page
+  is served with HTTP 200 as today.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When at least one requested Plaid Item fails to update, the `/plaid-update`
+  endpoint MUST respond with HTTP status 500 (Internal Server Error).
+- **FR-002**: When every requested Plaid Item updates successfully, or no Items were
+  updated, the endpoint MUST respond with HTTP status 200, as today.
+- **FR-003**: FR-001 and FR-002 MUST apply identically to all three response formats
+  (plain text, JSON, and browser HTML) and to both GET and POST requests.
+- **FR-004**: The response body in every format MUST be unchanged by this feature. It
+  still carries the complete per-Item results, including successful Items' counts and
+  failed Items' errors, so the caller can tell which Items failed and why.
+- **FR-005**: The endpoint documentation (the Plaid page's update API section and the HTTP
+  API page's summary) MUST describe the status codes the endpoint returns.
+
+### Key Entities
+
+- **Plaid update result**: the existing per-Item outcome record (Item, success flag,
+  counts of transactions added and updated, statement IDs, error). The status code is
+  derived from these records' success flags. No new data is stored.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of update requests where one or more Items fail, a caller that
+  only inspects the status code can tell the update did not fully succeed.
+- **SC-002**: In 100% of update requests where all Items succeed, the status code
+  reports success, so there are no false alarms.
+- **SC-003**: For every request, the response body carries the same information it did
+  before the change, so no caller loses detail about which Items failed.
+
+## Assumptions
+
+- **HTTP 500 is the failure status.** The issue asks only for "non-200". HTTP 500 is the
+  generic "the server could not fully complete this request" status, and it is what
+  `curl --fail`, monitoring tools, and scheduler wrappers already treat as failure. Other
+  candidates were rejected. 207 Multi-Status is a 2xx, so it is not detected as a failure.
+  502 Bad Gateway implies the fault is always upstream, but an update can fail for local
+  reasons too, such as a database error.
+- **Partial failure counts as failure.** A single failed Item makes the whole response
+  non-200. The caller can distinguish partial from total failure by reading the body.
+- **The browser view gets the same status.** A 500 status does not stop a browser from
+  rendering the results page, and applying one rule to every format keeps the endpoint
+  predictable. The interactive workflow is unchanged.
+- **This is a behaviour change for API callers.** Any existing script that treats a
+  non-200 as fatal and ignores the body will now see failures it previously missed.
+  That is the intent of the issue, and it is recorded in the changelog.

--- a/specs/20260911-160541-plaid-update-failure-status/tasks.md
+++ b/specs/20260911-160541-plaid-update-failure-status/tasks.md
@@ -99,13 +99,14 @@ None. No shared infrastructure, model, or migration is needed.
 - [X] T007 [P] In `docs/source/plaid.rst`, section "Updating Transactions via API", add a paragraph stating the status codes (200 all succeeded; 500 one or more Items failed, with the body still reporting every Item; 400 for a POST missing `item_ids`) and noting that `curl --fail` can therefore detect failed updates.
 - [X] T008 [P] In `docs/source/http_api.rst`, add the status-code rule to the one-paragraph `/plaid-update` summary (line ~804).
 - [X] T009 [P] In `CHANGES.rst`, add one concise bullet at the top of the `Unreleased` section, led by the `Issue #261` link. It says that `/plaid-update` now returns HTTP 500 when any Plaid Item fails to update (all response formats; body unchanged), with a short sub-bullet warning API callers that previously saw 200 on partial failure. Do not touch `biweeklybudget/version.py`.
-- [ ] T010 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
+- [X] T010 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
   - `tox -e py314`, which also covers pycodestyle and pyflakes.
   - `tox -e acceptance`.
   - `tox -e docs`.
 
   Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged by this change and run in CI.
-- [ ] T011 Record results in the spec artifacts: in `spec.md`, set Status to Complete, mark the tasks here done, and note the Test Gate results in `plan.md`. Commit with the prefix `Plaid Update Failure Status - M1.x`.
+- [X] T011 Record results in the spec artifacts: in `spec.md`, set Status to Complete, mark the tasks here done, and note the Test Gate results in `plan.md`. Commit with the prefix `Plaid Update Failure Status - M1.x`.
+  - Deviation, recorded here: T001's baseline run of the *unmodified* `TestPlaidUpdate` was not done separately. Instead, the first run came after the T002/T004 test edits but before T003. In that run the 19 untouched tests in the file passed, and exactly the 9 new or changed tests failed, which shows the same baseline.
 - [ ] T012 Push the branch to `origin`, open the pull request (following `.github/PULL_REQUEST_TEMPLATE.md`, and surfacing research R1/R2's choices for the maintainer), then monitor CI and answer reviews.
 
 ---

--- a/specs/20260911-160541-plaid-update-failure-status/tasks.md
+++ b/specs/20260911-160541-plaid-update-failure-status/tasks.md
@@ -1,0 +1,157 @@
+---
+
+description: "Task list for Plaid Update Reports Failure In Its Status Code"
+---
+
+# Tasks: Plaid Update Reports Failure In Its Status Code
+
+**Input**: Design documents from `specs/20260911-160541-plaid-update-failure-status/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/plaid-update.md, quickstart.md
+
+**Tests**: Included. The spec's success criteria SC-001/SC-002 are verified by them, and
+Constitution II requires new code to be covered by valid tests.
+
+**Organization**: Grouped by user story. Both stories are P1 and are delivered by the same
+few lines in one method, so they share the implementation task (T003) and differ in
+the cases their tests pin. The whole feature is one milestone (M1).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+
+## Path Conventions
+
+- View: `biweeklybudget/flaskapp/views/plaid.py`
+- View unit tests: `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py` (class `TestPlaidUpdate`)
+- Docs: `docs/source/plaid.rst`, `docs/source/http_api.rst`
+- Changelog: `CHANGES.rst`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: A working test environment, so the tests in Phase 3 can be seen to fail and then pass.
+
+- [ ] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), then confirm the unmodified `TestPlaidUpdate` class passes via `tox -e py314 -- biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`. That gives a green baseline before any change.
+
+---
+
+## Phase 2: Foundational
+
+None. No shared infrastructure, model, or migration is needed.
+
+---
+
+## Phase 3: User Story 1 — An unattended update that fails is detected (Priority: P1) 🎯 MVP
+
+**Goal**: A `/plaid-update` request in which any Plaid Item fails returns HTTP 500 in all three response formats, with an unchanged body.
+
+**Independent Test**: The US1 unit tests below pass. Manually, `quickstart.md` step 2 makes `curl --fail` exit 22 when an Item's login is reset.
+
+### Tests for User Story 1
+
+> Write these first and confirm they FAIL against the current code (which returns a bare body, i.e. implicitly 200).
+
+- [ ] T002 [US1] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
+  - Change the assertions in `test_update_template`, `test_update_plain`, and `test_update_plain_nondefault_num_days`. Each of these already includes a `success=False` result, so each must now assert `res == (<same body as today>, 500)`.
+  - Add `test_update_json_failure`: `Accept: application/json` with one successful and one failed result. Assert `res == (mock_json, 500)` and that `jsonify` is called with both results' `as_dict`.
+  - Add `test_update_all_failed`: `Accept: text/plain`, every result failed. Assert status 500 and a body listing each failure with `0 updated, 0 added, 2 account(s) failed`.
+
+### Implementation for User Story 1
+
+- [ ] T003 [US1] In `biweeklybudget/flaskapp/views/plaid.py`, `PlaidUpdate._update()`:
+  - Right after `results = updater.update(...)`, compute `status = 200 if all(r.success for r in results) else 500`.
+  - Return `(s, status)` from the `text/plain` branch, `(jsonify(...), status)` from the `application/json` branch, and `(render_template(...), status)` from the HTML branch.
+  - Change nothing else in the bodies (spec FR-004).
+  - Add a sentence to the `_update` docstring: HTTP 500 if any Item failed to update, else 200.
+
+**Checkpoint**: The T002 tests pass. US1 is delivered.
+
+---
+
+## Phase 4: User Story 2 — A fully successful update still reports success (Priority: P1)
+
+**Goal**: A `/plaid-update` request in which every Item succeeds, or there are no Items, still returns HTTP 200 with an unchanged body in all three formats.
+
+**Independent Test**: The US2 unit tests below pass.
+
+### Tests for User Story 2
+
+- [ ] T004 [US2] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
+  - Change `test_update_json`, which is all-successful, to assert `res == (mock_json, 200)`.
+  - Add `test_update_template_all_success`: default `Accept`, all results successful. Assert `res == (rendered, 200)` and `render_template` called with `num_failed=0`.
+  - Add `test_update_plain_all_success`: `text/plain`, all results successful. Assert status 200 and a body ending `0 account(s) failed`.
+  - Add `test_update_no_items`: `update()` returns `[]`. Assert status 200 for the JSON format, with `jsonify([])`.
+
+### Implementation for User Story 2
+
+- [ ] T005 [US2] No further code beyond T003, since `all([])` is `True` and so gives 200. Confirm the T004 tests pass against the T003 change, and fix T003 if they don't.
+
+**Checkpoint**: Both stories pass.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T006 [P] In `biweeklybudget/flaskapp/views/plaid.py`, extend the `PlaidUpdate` class docstring's response-format list with the status rule: HTTP 200 when every Item updated successfully, HTTP 500 when one or more failed. The body is the same in both cases.
+- [ ] T007 [P] In `docs/source/plaid.rst`, section "Updating Transactions via API", add a paragraph stating the status codes (200 all succeeded; 500 one or more Items failed, with the body still reporting every Item; 400 for a POST missing `item_ids`) and noting that `curl --fail` can therefore detect failed updates.
+- [ ] T008 [P] In `docs/source/http_api.rst`, add the status-code rule to the one-paragraph `/plaid-update` summary (line ~804).
+- [ ] T009 [P] In `CHANGES.rst`, add one concise bullet at the top of the `Unreleased` section, led by the `Issue #261` link. It says that `/plaid-update` now returns HTTP 500 when any Plaid Item fails to update (all response formats; body unchanged), with a short sub-bullet warning API callers that previously saw 200 on partial failure. Do not touch `biweeklybudget/version.py`.
+- [ ] T010 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
+  - `tox -e py314`, which also covers pycodestyle and pyflakes.
+  - `tox -e acceptance`.
+  - `tox -e docs`.
+
+  Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged by this change and run in CI.
+- [ ] T011 Record results in the spec artifacts: in `spec.md`, set Status to Complete, mark the tasks here done, and note the Test Gate results in `plan.md`. Commit with the prefix `Plaid Update Failure Status - M1.x`.
+- [ ] T012 Push the branch to `origin`, open the pull request (following `.github/PULL_REQUEST_TEMPLATE.md`, and surfacing research R1/R2's choices for the maintainer), then monitor CI and answer reviews.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001)** blocks everything that runs tests.
+- **US1**: T002 (tests, failing) → T003 (implementation) → T002 tests pass.
+- **US2**: T004 depends on T003 only in that its tests pass once T003 is in. It may be written alongside T002, but both edit the same test file, so they're done sequentially. T005 is verification.
+- **Polish**: T006–T009 touch different files and can be done in parallel once T003 is done. T010 depends on all of T002–T009. T011 depends on T010. T012 depends on T011.
+
+### User Story Dependencies
+
+- US1 and US2 share T003. US2 needs no code of its own but is independently testable through its own test cases.
+
+### Parallel Opportunities
+
+- T006, T007, T008, T009 (four different files).
+- Within T010, the `py314`, `acceptance`, and `docs` tox environments can run concurrently if the database container can serve both the unit and acceptance suites. Otherwise run them sequentially, since both suites reload the test database.
+
+---
+
+## Parallel Example: Polish
+
+```bash
+Task: "Extend the PlaidUpdate class docstring in biweeklybudget/flaskapp/views/plaid.py"
+Task: "Document status codes in docs/source/plaid.rst"
+Task: "Document status codes in docs/source/http_api.rst"
+Task: "Add Unreleased entry to CHANGES.rst"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+T001 → T002 → T003 is the MVP: failures are detectable. T004–T005 lock in that success is
+still 200, and T006–T012 document, verify, and deliver. At this size all of it ships
+together as milestone M1 in one pull request.
+
+---
+
+## Notes
+
+- Bodies must not change (FR-004). Every changed assertion compares against the same body object or string as before, so a body regression fails the test.
+- Unit tests need the MariaDB container (see `CLAUDE.md`). Without it, `test_plaid.py` and `test_utils.py` fail to collect.

--- a/specs/20260911-160541-plaid-update-failure-status/tasks.md
+++ b/specs/20260911-160541-plaid-update-failure-status/tasks.md
@@ -107,7 +107,7 @@ None. No shared infrastructure, model, or migration is needed.
   Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged by this change and run in CI.
 - [X] T011 Record results in the spec artifacts: in `spec.md`, set Status to Complete, mark the tasks here done, and note the Test Gate results in `plan.md`. Commit with the prefix `Plaid Update Failure Status - M1.x`.
   - Deviation, recorded here: T001's baseline run of the *unmodified* `TestPlaidUpdate` was not done separately. Instead, the first run came after the T002/T004 test edits but before T003. In that run the 19 untouched tests in the file passed, and exactly the 9 new or changed tests failed, which shows the same baseline.
-- [ ] T012 Push the branch to `origin`, open the pull request (following `.github/PULL_REQUEST_TEMPLATE.md`, and surfacing research R1/R2's choices for the maintainer), then monitor CI and answer reviews.
+- [X] T012 Push the branch to `origin`, open the pull request (following `.github/PULL_REQUEST_TEMPLATE.md`, and surfacing research R1/R2's choices for the maintainer), then monitor CI and answer reviews.
 
 ---
 

--- a/specs/20260911-160541-plaid-update-failure-status/tasks.md
+++ b/specs/20260911-160541-plaid-update-failure-status/tasks.md
@@ -34,7 +34,7 @@ the cases their tests pin. The whole feature is one milestone (M1).
 
 **Purpose**: A working test environment, so the tests in Phase 3 can be seen to fail and then pass.
 
-- [ ] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), then confirm the unmodified `TestPlaidUpdate` class passes via `tox -e py314 -- biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`. That gives a green baseline before any change.
+- [X] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), then confirm the unmodified `TestPlaidUpdate` class passes via `tox -e py314 -- biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`. That gives a green baseline before any change.
 
 ---
 
@@ -54,14 +54,14 @@ None. No shared infrastructure, model, or migration is needed.
 
 > Write these first and confirm they FAIL against the current code (which returns a bare body, i.e. implicitly 200).
 
-- [ ] T002 [US1] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
+- [X] T002 [US1] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
   - Change the assertions in `test_update_template`, `test_update_plain`, and `test_update_plain_nondefault_num_days`. Each of these already includes a `success=False` result, so each must now assert `res == (<same body as today>, 500)`.
   - Add `test_update_json_failure`: `Accept: application/json` with one successful and one failed result. Assert `res == (mock_json, 500)` and that `jsonify` is called with both results' `as_dict`.
   - Add `test_update_all_failed`: `Accept: text/plain`, every result failed. Assert status 500 and a body listing each failure with `0 updated, 0 added, 2 account(s) failed`.
 
 ### Implementation for User Story 1
 
-- [ ] T003 [US1] In `biweeklybudget/flaskapp/views/plaid.py`, `PlaidUpdate._update()`:
+- [X] T003 [US1] In `biweeklybudget/flaskapp/views/plaid.py`, `PlaidUpdate._update()`:
   - Right after `results = updater.update(...)`, compute `status = 200 if all(r.success for r in results) else 500`.
   - Return `(s, status)` from the `text/plain` branch, `(jsonify(...), status)` from the `application/json` branch, and `(render_template(...), status)` from the HTML branch.
   - Change nothing else in the bodies (spec FR-004).
@@ -79,7 +79,7 @@ None. No shared infrastructure, model, or migration is needed.
 
 ### Tests for User Story 2
 
-- [ ] T004 [US2] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
+- [X] T004 [US2] In `biweeklybudget/tests/unit/flaskapp/views/test_plaid.py`, class `TestPlaidUpdate`:
   - Change `test_update_json`, which is all-successful, to assert `res == (mock_json, 200)`.
   - Add `test_update_template_all_success`: default `Accept`, all results successful. Assert `res == (rendered, 200)` and `render_template` called with `num_failed=0`.
   - Add `test_update_plain_all_success`: `text/plain`, all results successful. Assert status 200 and a body ending `0 account(s) failed`.
@@ -87,7 +87,7 @@ None. No shared infrastructure, model, or migration is needed.
 
 ### Implementation for User Story 2
 
-- [ ] T005 [US2] No further code beyond T003, since `all([])` is `True` and so gives 200. Confirm the T004 tests pass against the T003 change, and fix T003 if they don't.
+- [X] T005 [US2] No further code beyond T003, since `all([])` is `True` and so gives 200. Confirm the T004 tests pass against the T003 change, and fix T003 if they don't.
 
 **Checkpoint**: Both stories pass.
 
@@ -95,10 +95,10 @@ None. No shared infrastructure, model, or migration is needed.
 
 ## Phase 5: Polish & Cross-Cutting Concerns
 
-- [ ] T006 [P] In `biweeklybudget/flaskapp/views/plaid.py`, extend the `PlaidUpdate` class docstring's response-format list with the status rule: HTTP 200 when every Item updated successfully, HTTP 500 when one or more failed. The body is the same in both cases.
-- [ ] T007 [P] In `docs/source/plaid.rst`, section "Updating Transactions via API", add a paragraph stating the status codes (200 all succeeded; 500 one or more Items failed, with the body still reporting every Item; 400 for a POST missing `item_ids`) and noting that `curl --fail` can therefore detect failed updates.
-- [ ] T008 [P] In `docs/source/http_api.rst`, add the status-code rule to the one-paragraph `/plaid-update` summary (line ~804).
-- [ ] T009 [P] In `CHANGES.rst`, add one concise bullet at the top of the `Unreleased` section, led by the `Issue #261` link. It says that `/plaid-update` now returns HTTP 500 when any Plaid Item fails to update (all response formats; body unchanged), with a short sub-bullet warning API callers that previously saw 200 on partial failure. Do not touch `biweeklybudget/version.py`.
+- [X] T006 [P] In `biweeklybudget/flaskapp/views/plaid.py`, extend the `PlaidUpdate` class docstring's response-format list with the status rule: HTTP 200 when every Item updated successfully, HTTP 500 when one or more failed. The body is the same in both cases.
+- [X] T007 [P] In `docs/source/plaid.rst`, section "Updating Transactions via API", add a paragraph stating the status codes (200 all succeeded; 500 one or more Items failed, with the body still reporting every Item; 400 for a POST missing `item_ids`) and noting that `curl --fail` can therefore detect failed updates.
+- [X] T008 [P] In `docs/source/http_api.rst`, add the status-code rule to the one-paragraph `/plaid-update` summary (line ~804).
+- [X] T009 [P] In `CHANGES.rst`, add one concise bullet at the top of the `Unreleased` section, led by the `Issue #261` link. It says that `/plaid-update` now returns HTTP 500 when any Plaid Item fails to update (all response formats; body unchanged), with a short sub-bullet warning API callers that previously saw 200 on partial failure. Do not touch `biweeklybudget/version.py`.
 - [ ] T010 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
   - `tox -e py314`, which also covers pycodestyle and pyflakes.
   - `tox -e acceptance`.


### PR DESCRIPTION
Implements #261: `/plaid-update` now returns **HTTP 500** when any Plaid Item fails to update, and **HTTP 200** otherwise.

## What changed

- `PlaidUpdate._update()` (`biweeklybudget/flaskapp/views/plaid.py`) computes one status from the per-Item `PlaidUpdateResult`s. It's 500 if any result has `success == False`, otherwise 200, which includes the case where there were no Items to update. That status goes back with all three response formats: plain text, JSON, and the browser HTML page.
- **Response bodies are unchanged.** The body still reports every Item's result, including the error for each failed one, so a caller can see what failed and why.
- The request handlers' 400 for a POST missing `item_ids`, and the GET form view, are unchanged.
- Docs: `docs/source/plaid.rst` (update API section), `docs/source/http_api.rst` (summary), and the `PlaidUpdate` / `_update` docstrings now describe the status codes.
- `CHANGES.rst`: one entry under `Unreleased`. `version.py` is not touched.

## Decisions for you to confirm

The issue asks only for "non-200". Two judgement calls were made, both recorded with reasoning in `specs/20260911-160541-plaid-update-failure-status/research.md`:

1. **HTTP 500 specifically (R1).** `PlaidUpdater._do_item()` catches *every* exception, whether an expired login, a Plaid API error, or a local DB error, so "the server couldn't complete the requested work" is the accurate description. 207 Multi-Status was rejected because it's a 2xx, so `curl --fail` and monitors would still report success. 502 was rejected because it implies the fault is always upstream.
2. **The browser HTML view gets the same status (R2).** Browsers render a 500 page's body normally, so the interactive results page looks the same, and the rule doesn't depend on the `Accept` header.

This is a behaviour change for API callers: anything treating non-200 as fatal will now see partial failures. That is the point of the issue, and the changelog says so.

## Tests

- Four existing `TestPlaidUpdate` `_update` tests now assert `(body, status)`, with the body compared against exactly what it was before.
- Five new tests cover JSON with a failure (500), plain text with every Item failed (500), HTML all-successful (200), plain text all-successful (200), and no Items (200).
- The new assertions were run against the unchanged view code first and failed (9 failures), then passed once the change was in.

### Test Gate (Constitution II)

Run locally to completion against MariaDB 10.4.7 (the CI image), Python 3.14.7:

| Suite | Result |
|-------|--------|
| `tox -e py314` (unit + pycodestyle + pyflakes) | 889 passed, 5 skipped, 0 failed. `views/plaid.py` at 100% line and branch coverage |
| `tox -e acceptance` | 793 passed, 24 skipped, 0 failed (17m03s) |
| `tox -e docs` | builds with no broken links and no new warnings |

The `migrations`, `docker`, and `plaid` suites aren't engaged by this change (no schema, packaging, or Plaid-updater change) and run in CI. The browser flow that exercises a failing update (`test_plaidlink.py::test_17`) is in the `plaid` suite. It asserts only the rendered page, which is unchanged, and Selenium can't see status codes.

## Spec Kit artifacts

`specs/20260911-160541-plaid-update-failure-status/`: spec, plan (including the Constitution Check), research, data model, the endpoint's status-code contract, quickstart, and tasks. The feature is one milestone (M1).

# Pull Request Checklist

- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Code should conform to the following:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests).
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] An entry for this change has been added at the top of ``CHANGES.rst``, under the ``Unreleased`` heading. ``version.py`` is not changed.
    - [x] The changelog entry is concise; background and rationale are in this description.
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** are meaningful and reference the feature/milestone; this PR references issue #261.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in biweeklybudget, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the biweeklybudget project (the Affero GPL v3,
  or any subsequent version of that license if adopted by biweeklybudget).
* My contribution may perpetually be included in and distributed with biweeklybudget; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of biweeklybudget's license.
* I have the legal power and rights to agree to these terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xmq4dbuLxV6bdkTsMonAcY
