### PR TITLE
Fuel Log - Configurable fuel levels (#208)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+* `Issue #208 <https://github.com/jantman/biweeklybudget/issues/208>`_ - The fuel level choices on the Add Fuel Fill form are now configurable with the new ``FUEL_LEVELS`` setting, for gauges not marked in tenths. The default, ``0/10`` through ``10/10``, is unchanged, and levels are still stored as percentages.
+
+  * As an environment variable, give comma-separated ``label:percentage`` pairs, e.g. ``FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"``. An invalid value stops the application from starting.
+
 * `Issue #261 <https://github.com/jantman/biweeklybudget/issues/261>`_ - ``/plaid-update`` now returns HTTP 500 instead of 200 when any Plaid Item fails to update, in all response formats. The response body is unchanged.
 
   * Scripts calling the endpoint (for example with ``curl --fail``) will now see partial failures as errors.

--- a/biweeklybudget/flaskapp/static/js/budgets_modal.js
+++ b/biweeklybudget/flaskapp/static/js/budgets_modal.js
@@ -55,24 +55,6 @@ function budgetModalDivHandleType() {
 }
 
 /**
- * Escape a string for interpolation into HTML text content.
- *
- * Account names are entered by the user, so they cannot be concatenated into
- * an HTML string as-is.
- *
- * @param {String} s - the string to escape
- * @return {String} the escaped string
- */
-function escapeHtml(s) {
-    return String(s)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-/**
  * Generate the HTML for the "Held in accounts" checkboxes on the budget
  * modal, one per active budget-funding account.
  *

--- a/biweeklybudget/flaskapp/static/js/custom.js
+++ b/biweeklybudget/flaskapp/static/js/custom.js
@@ -199,3 +199,22 @@ function isoformat(d) {
           (dd>9 ? '' : '0') + dd
          ].join('-');
 }
+
+/**
+ * Escape a string for interpolation into HTML text content or a quoted
+ * attribute value.
+ *
+ * Use this for any user-entered or configured text (such as account names or
+ * fuel level labels) that is concatenated into an HTML string.
+ *
+ * @param {String} s - the string to escape
+ * @return {String} the escaped string
+ */
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/biweeklybudget/flaskapp/static/js/fuel.js
+++ b/biweeklybudget/flaskapp/static/js/fuel.js
@@ -36,6 +36,25 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 */
 
 /**
+ * Build the options for a fuel level select from the ``FUEL_LEVELS`` setting,
+ * which ``fuel.html`` templates into the page as an Array of
+ * ``[label, percentage]`` pairs. Options keep the configured order, and labels
+ * are HTML-escaped because they are configured text.
+ *
+ * @param {number} selectedValue - the percentage to preselect
+ * @return {Array} options for :js:func:`FormBuilder.addSelect`
+ */
+function fuelLevelOptions(selectedValue) {
+    return FUEL_LEVELS.map(function (level) {
+        return {
+            value: level[1],
+            label: escapeHtml(level[0]),
+            selected: level[1] === selectedValue
+        };
+    });
+}
+
+/**
  * Generate the HTML for the form on the Modal
  */
 function fuelModalDivForm() {
@@ -45,6 +64,9 @@ function fuelModalDivForm() {
             vehicleOptions[vehicles[key].name] = key;
         }
     });
+    var levelPercentages = FUEL_LEVELS.map(function (level) { return level[1]; });
+    var emptiestLevel = Math.min.apply(null, levelPercentages);
+    var fullestLevel = Math.max.apply(null, levelPercentages);
     return new FormBuilder('fuelLogForm')
         .addLabelToValueSelect('fuel_frm_vehicle', 'vehicle', 'Vehicle', vehicleOptions, null, false)
         .addDatePicker('fuel_frm_date', 'date', 'Date')
@@ -62,15 +84,13 @@ function fuelModalDivForm() {
                 helpBlock: 'Distance since last fill, as reported by vehicle'
             }
         )
-        .addLabelToValueSelect(
+        .addSelect(
             'fuel_frm_level_before', 'level_before', 'Starting Fuel Level',
-            {'0/10': 0, '1/10': 10, '2/10': 20, '3/10': 30, '4/10': 40, '5/10': 50, '6/10': 60, '7/10': 70, '8/10': 80, '9/10': 90, '10/10': 100},
-            0, false
+            fuelLevelOptions(emptiestLevel)
         )
-        .addLabelToValueSelect(
+        .addSelect(
             'fuel_frm_level_after', 'level_after', 'Ending Fuel Level',
-            {'0/10': 0, '1/10': 10, '2/10': 20, '3/10': 30, '4/10': 40, '5/10': 50, '6/10': 60, '7/10': 70, '8/10': 80, '9/10': 90, '10/10': 100},
-            100, false
+            fuelLevelOptions(fullestLevel)
         )
         .addText('fuel_frm_fill_loc', 'fill_location', 'Fill Location')
         .addCurrency('fuel_frm_cost_per_gallon', 'cost_per_gallon', 'Cost Per ' + FUEL_VOLUME_UNIT)

--- a/biweeklybudget/flaskapp/templates/fuel.html
+++ b/biweeklybudget/flaskapp/templates/fuel.html
@@ -154,6 +154,7 @@
 <script>
 var default_account_id = {{ settings.DEFAULT_ACCOUNT_ID }};
 var fuel_budget_id = {{ settings.FUEL_BUDGET_ID }};
+var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};
 </script>
 
 <script src="/static/js/forms.js"></script>

--- a/biweeklybudget/settings.py
+++ b/biweeklybudget/settings.py
@@ -125,6 +125,31 @@ DISTANCE_UNIT_ABBREVIATION = 'Mi.'
 #: such as ``MPG`` or ``KM/L``.
 FUEL_ECO_ABBREVIATION = 'MPG'
 
+#: list - The fuel levels offered as the "Starting Fuel Level" and "Ending
+#: Fuel Level" choices on the Fuel Log's Add Fuel Fill form, so that they can
+#: match the markings on your vehicle's fuel gauge. This is an ordered list of
+#: ``(label, percentage)`` pairs: ``label`` is the text shown in the form, and
+#: ``percentage`` is the whole-number percentage of a full tank (0 to 100)
+#: that the label stands for, which is what is stored for the fill. The choices
+#: are shown in the order given; the starting level defaults to the one with
+#: the lowest percentage and the ending level to the one with the highest.
+#:
+#: Defaults to tenths of a tank, ``0/10`` (0) through ``10/10`` (100). For a
+#: gauge marked in quarters, set it to
+#: ``[('E', 0), ('1/4', 25), ('1/2', 50), ('3/4', 75), ('F', 100)]``.
+#: Fractions that are not a whole percentage must be rounded, e.g. ``1/8`` as
+#: ``13``.
+#:
+#: As an environment variable, give comma-separated ``label:percentage``
+#: entries, e.g. ``FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"``. Each entry is
+#: split at its last colon, and whitespace around labels and percentages is
+#: ignored; labels given this way cannot contain commas.
+#:
+#: The list must have at least two levels, with non-empty labels, integer
+#: percentages from 0 to 100, and no duplicated labels or percentages. If it
+#: doesn't, the application exits at startup with an error saying why.
+FUEL_LEVELS = [('%d/10' % i, i * 10) for i in range(11)]
+
 #: string - SQLAlchemy database connection string. See the
 #: :ref:`SQLAlchemy Database URLS docs <sqlalchemy:database_urls>`
 #: for further information.
@@ -232,6 +257,88 @@ PLAID_COUNTRY_CODES = None
 #: Since this is a single-user app, we just hard-code to "1"
 PLAID_USER_ID = '1'
 
+
+def parse_fuel_levels(value):
+    """
+    Parse the ``FUEL_LEVELS`` environment variable format into a list of
+    ``(label, percentage)`` tuples. See
+    :py:attr:`biweeklybudget.settings.FUEL_LEVELS` for the format. This only
+    parses; the result must still be checked with
+    :py:func:`~.validate_fuel_levels`.
+
+    :param value: comma-separated ``label:percentage`` entries
+    :type value: str
+    :return: list of (label, percentage) tuples, in the order given
+    :rtype: list
+    :raises ValueError: if an entry is not ``label:percentage`` with a
+      whole-number percentage
+    """
+    result = []
+    for entry in value.split(','):
+        label, sep, pct = entry.rpartition(':')
+        pct = pct.strip()
+        if sep == '':
+            raise ValueError(
+                'entry %r is not in label:percentage form' % entry
+            )
+        if not (pct.isascii() and pct.isdigit()):
+            raise ValueError(
+                'entry %r percentage %r is not a whole number' % (entry, pct)
+            )
+        result.append((label.strip(), int(pct)))
+    return result
+
+
+def validate_fuel_levels(levels):
+    """
+    Check a ``FUEL_LEVELS`` value, from the settings module or parsed from the
+    environment, and return it normalised to a new list of
+    ``(label, percentage)`` tuples with surrounding whitespace removed from the
+    labels. See :py:attr:`biweeklybudget.settings.FUEL_LEVELS`.
+
+    :param levels: sequence of (label, percentage) pairs
+    :type levels: list or tuple
+    :return: list of (label, percentage) tuples, in the order given
+    :rtype: list
+    :raises ValueError: if there are fewer than two levels, a level is not a
+      (label, percentage) pair, a label is empty or not a string, a
+      percentage is not an integer from 0 to 100, or a label or percentage
+      is duplicated
+    """
+    if not isinstance(levels, (list, tuple)):
+        raise ValueError(
+            'must be a list of (label, percentage) pairs, not %r' % (levels,)
+        )
+    if len(levels) < 2:
+        raise ValueError(
+            'must have at least two levels, but has %d' % len(levels)
+        )
+    result = []
+    for level in levels:
+        if not isinstance(level, (list, tuple)) or len(level) != 2:
+            raise ValueError(
+                'level %r is not a (label, percentage) pair' % (level,)
+            )
+        label, pct = level
+        if not isinstance(label, str) or label.strip() == '':
+            raise ValueError('level %r has an empty label' % (level,))
+        label = label.strip()
+        if isinstance(pct, bool) or not isinstance(pct, int):
+            raise ValueError(
+                'level %r percentage is not an integer' % (level,)
+            )
+        if pct < 0 or pct > 100:
+            raise ValueError(
+                'level %r percentage %d is not from 0 to 100' % (level, pct)
+            )
+        if label in [x[0] for x in result]:
+            raise ValueError('label %r is used more than once' % label)
+        if pct in [x[1] for x in result]:
+            raise ValueError('percentage %d is used more than once' % pct)
+        result.append((label, pct))
+    return result
+
+
 if 'SETTINGS_MODULE' in os.environ:
     logger.debug('Attempting to import settings module %s',
                  os.environ['SETTINGS_MODULE'])
@@ -286,6 +393,17 @@ for varname in _DATE_VARS:
         raise SystemExit('ERROR: env var %s cannot parse as %Y-%m-%d' % varname)
     logger.debug('Setting %S from env var: %s', varname, value)
     globals()[varname] = value
+
+# FUEL_LEVELS may come from the settings module or the environment; either way
+# it is validated, so a mistake stops startup rather than producing a form that
+# records the wrong levels.
+try:
+    if 'FUEL_LEVELS' in os.environ:
+        FUEL_LEVELS = parse_fuel_levels(os.environ['FUEL_LEVELS'])
+        logger.debug('Setting FUEL_LEVELS from env var: %s', FUEL_LEVELS)
+    FUEL_LEVELS = validate_fuel_levels(FUEL_LEVELS)
+except ValueError as ex:
+    raise SystemExit('ERROR: FUEL_LEVELS setting is invalid: %s' % ex)
 
 for varname in _REQUIRED_VARS:
     if globals().get(varname, None) is None:

--- a/biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py
+++ b/biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py
@@ -408,6 +408,11 @@ class TestModals(AcceptanceHelper):
 
     def test_11_fuel_populate_modal(self, base_url, selenium):
         self.get(selenium, base_url + '/fuel')
+        # the FUEL_LEVELS setting (the default, in the test settings) is
+        # rendered into the page for fuel.js to build the level selects from
+        assert selenium.execute_script('return FUEL_LEVELS;') == [
+            [label, int(value)] for value, label in LEVEL_OPTS
+        ]
         link = selenium.find_element(By.ID, 'btn-add-fuel')
         self.wait_until_clickable(selenium, 'btn-add-fuel')
         modal, title, body = self.try_click_and_get_modal(selenium, link)
@@ -708,3 +713,130 @@ class TestModals(AcceptanceHelper):
         assert len(trans.budget_transactions) == 1
         assert trans.budget_transactions[0].budget_id == 1
         assert trans.budget_transactions[0].amount == Decimal('14.82')
+
+
+#: A FUEL_LEVELS value for a gauge marked in quarters, as JavaScript source.
+QUARTERS_JS = "[['E', 0], ['1/4', 25], ['1/2', 50], ['3/4', 75], ['F', 100]]"
+
+
+@pytest.mark.acceptance
+@pytest.mark.usefixtures('class_refresh_db', 'refreshdb', 'testflask')
+@pytest.mark.incremental
+class TestFuelLevelsConfigured(AcceptanceHelper):
+    """
+    The Add Fuel Fill form with a non-default ``FUEL_LEVELS`` setting.
+
+    The live server is shared by the whole session and uses the test settings
+    module's default list, so these tests replace the page's ``FUEL_LEVELS``
+    global (which the server renders from the setting; see
+    ``TestModals.test_11_fuel_populate_modal``) before opening the modal.
+    """
+
+    def open_modal_with_levels(self, base_url, selenium, levels_js):
+        self.get(selenium, base_url + '/fuel')
+        selenium.execute_script('FUEL_LEVELS = %s;' % levels_js)
+        link = selenium.find_element(By.ID, 'btn-add-fuel')
+        self.wait_until_clickable(selenium, 'btn-add-fuel')
+        modal, title, body = self.try_click_and_get_modal(selenium, link)
+        self.assert_modal_displayed(modal, title, body)
+        assert title.text == 'Add Fuel Fill'
+        return body
+
+    def test_1_custom_levels(self, base_url, selenium):
+        self.open_modal_with_levels(base_url, selenium, QUARTERS_JS)
+        expected = [
+            ['0', 'E'], ['25', '1/4'], ['50', '1/2'], ['75', '3/4'],
+            ['100', 'F']
+        ]
+        lvl_before = Select(
+            selenium.find_element(By.ID, 'fuel_frm_level_before')
+        )
+        opts = [[o.get_attribute('value'), o.text] for o in lvl_before.options]
+        assert opts == expected
+        assert lvl_before.first_selected_option.get_attribute('value') == '0'
+        lvl_after = Select(
+            selenium.find_element(By.ID, 'fuel_frm_level_after')
+        )
+        opts = [[o.get_attribute('value'), o.text] for o in lvl_after.options]
+        assert opts == expected
+        assert lvl_after.first_selected_option.get_attribute('value') == '100'
+
+    def test_2_add_fill(self, base_url, selenium):
+        self.open_modal_with_levels(base_url, selenium, QUARTERS_JS)
+        Select(
+            selenium.find_element(By.ID, 'fuel_frm_vehicle')
+        ).select_by_value('2')
+        date = selenium.find_element(By.ID, 'fuel_frm_date')
+        date.clear()
+        date.send_keys(
+            (dtnow() - timedelta(days=1)).date().strftime('%Y-%m-%d')
+        )
+        odo = selenium.find_element(By.ID, 'fuel_frm_odo_miles')
+        odo.clear()
+        odo.send_keys('1408')
+        rep_mi = selenium.find_element(By.ID, 'fuel_frm_reported_miles')
+        rep_mi.clear()
+        rep_mi.send_keys('105')
+        Select(
+            selenium.find_element(By.ID, 'fuel_frm_level_before')
+        ).select_by_visible_text('1/4')
+        Select(
+            selenium.find_element(By.ID, 'fuel_frm_level_after')
+        ).select_by_visible_text('F')
+        fill_loc = selenium.find_element(By.ID, 'fuel_frm_fill_loc')
+        fill_loc.clear()
+        fill_loc.send_keys('Quarters Station')
+        cpg = selenium.find_element(By.ID, 'fuel_frm_cost_per_gallon')
+        cpg.clear()
+        cpg.send_keys('3.009')
+        cost = selenium.find_element(By.ID, 'fuel_frm_total_cost')
+        cost.clear()
+        cost.send_keys('30.09')
+        gals = selenium.find_element(By.ID, 'fuel_frm_gallons')
+        gals.clear()
+        gals.send_keys('10.000')
+        rep_mpg = selenium.find_element(By.ID, 'fuel_frm_reported_mpg')
+        rep_mpg.clear()
+        rep_mpg.send_keys('30.1')
+        add_trans = selenium.find_element(By.ID, 'fuel_frm_add_trans')
+        add_trans.click()
+        assert add_trans.is_selected() is False
+        selenium.find_element(By.ID, 'modalSaveButton').click()
+        self.wait_for_jquery_done(selenium)
+        _, _, body = self.get_modal_parts(selenium)
+        x = body.find_elements(By.TAG_NAME, 'div')[0]
+        assert 'alert-success' in x.get_attribute('class')
+        assert x.text.strip().startswith('Successfully saved FuelFill ')
+        assert x.text.strip().endswith(' in database.')
+        selenium.find_element(By.ID, 'modalCloseButton').click()
+        self.wait_for_jquery_done(selenium)
+
+    def test_3_verify_db(self, testdb):
+        fills = testdb.query(FuelFill).filter(
+            FuelFill.fill_location == 'Quarters Station'
+        ).all()
+        assert len(fills) == 1
+        assert fills[0].vehicle_id == 2
+        assert fills[0].odometer_miles == 1408
+        assert fills[0].level_before == 25
+        assert fills[0].level_after == 100
+
+    def test_4_numeric_and_markup_labels(self, base_url, selenium):
+        # integer-like labels, out of numeric order, and a label containing
+        # markup that must be shown as literal text
+        self.open_modal_with_levels(
+            base_url, selenium,
+            "[['8', 100], ['4', 50], ['<b>0</b> & E', 0]]"
+        )
+        expected = [['100', '8'], ['50', '4'], ['0', '<b>0</b> & E']]
+        for sel_id, selected in [
+            ('fuel_frm_level_before', '0'),
+            ('fuel_frm_level_after', '100')
+        ]:
+            elem = selenium.find_element(By.ID, sel_id)
+            assert elem.find_elements(By.TAG_NAME, 'b') == []
+            sel = Select(elem)
+            opts = [[o.get_attribute('value'), o.text] for o in sel.options]
+            assert opts == expected
+            assert sel.first_selected_option.get_attribute(
+                'value') == selected

--- a/biweeklybudget/tests/unit/test_settings_fuel_levels.py
+++ b/biweeklybudget/tests/unit/test_settings_fuel_levels.py
@@ -1,0 +1,208 @@
+"""
+The latest version of this package is available at:
+<http://github.com/jantman/biweeklybudget>
+
+################################################################################
+Copyright 2016-2024 Jason Antman <http://www.jasonantman.com>
+
+    This file is part of biweeklybudget, also known as biweeklybudget.
+
+    biweeklybudget is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    biweeklybudget is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with biweeklybudget.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/biweeklybudget> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from biweeklybudget import settings
+from biweeklybudget.settings import parse_fuel_levels, validate_fuel_levels
+
+#: The fuel level options that were hard-coded in fuel.js before GitHub
+#: issue #208; the default must stay exactly this.
+TENTHS = [
+    ('0/10', 0), ('1/10', 10), ('2/10', 20), ('3/10', 30), ('4/10', 40),
+    ('5/10', 50), ('6/10', 60), ('7/10', 70), ('8/10', 80), ('9/10', 90),
+    ('10/10', 100)
+]
+
+
+def import_settings_with_env(fuel_levels):
+    """
+    Import :py:mod:`biweeklybudget.settings` in a fresh interpreter with the
+    ``FUEL_LEVELS`` environment variable set, and print the resulting setting
+    as JSON. A subprocess is used because the setting is processed at import
+    time, and reloading the shared module in this process would leave it
+    half-initialised for every other test if the import failed.
+
+    :param fuel_levels: value for the FUEL_LEVELS environment variable
+    :type fuel_levels: str
+    :return: the completed process
+    :rtype: subprocess.CompletedProcess
+    """
+    env = dict(os.environ)
+    env['FUEL_LEVELS'] = fuel_levels
+    # importing settings requires DB_CONNSTRING; it does not connect.
+    env.setdefault(
+        'DB_CONNSTRING', 'mysql+pymysql://user:pass@127.0.0.1/unused'
+    )
+    return subprocess.run(
+        [
+            sys.executable, '-c',
+            'import json; from biweeklybudget import settings; '
+            'print(json.dumps(settings.FUEL_LEVELS))'
+        ],
+        env=env, capture_output=True, text=True, timeout=120
+    )
+
+
+class TestFuelLevelsDefault:
+
+    def test_default(self):
+        # the test settings module does not set FUEL_LEVELS
+        assert settings.FUEL_LEVELS == TENTHS
+
+
+class TestParseFuelLevels:
+
+    def test_quarters(self):
+        assert parse_fuel_levels('E:0,1/4:25,1/2:50,3/4:75,F:100') == [
+            ('E', 0), ('1/4', 25), ('1/2', 50), ('3/4', 75), ('F', 100)
+        ]
+
+    def test_whitespace_is_stripped(self):
+        assert parse_fuel_levels(' E : 0 , F:100 ') == [('E', 0), ('F', 100)]
+
+    def test_label_may_contain_colon(self):
+        assert parse_fuel_levels('a:b:50,F:100') == [('a:b', 50), ('F', 100)]
+
+    def test_order_is_kept(self):
+        assert parse_fuel_levels('F:100,E:0') == [('F', 100), ('E', 0)]
+
+    @pytest.mark.parametrize('value', [
+        'E:x,F:100',
+        'E:-5,F:100',
+        'E:1.5,F:100',
+        'E:,F:100',
+        'E0,F:100',
+        'E:0,F:100,',
+        '',
+    ])
+    def test_invalid(self, value):
+        with pytest.raises(ValueError):
+            parse_fuel_levels(value)
+
+
+class TestValidateFuelLevels:
+
+    def test_tuples(self):
+        assert validate_fuel_levels(TENTHS) == TENTHS
+
+    def test_lists_are_normalised_to_tuples(self):
+        assert validate_fuel_levels([['E', 0], ['F', 100]]) == [
+            ('E', 0), ('F', 100)
+        ]
+
+    def test_tuple_of_levels(self):
+        assert validate_fuel_levels((('E', 0), ('F', 100))) == [
+            ('E', 0), ('F', 100)
+        ]
+
+    def test_labels_are_stripped(self):
+        assert validate_fuel_levels([(' E ', 0), ('F', 100)]) == [
+            ('E', 0), ('F', 100)
+        ]
+
+    def test_out_of_order_is_kept(self):
+        levels = [('8', 100), ('4', 50), ('0', 0)]
+        assert validate_fuel_levels(levels) == levels
+
+    def test_boundaries_accepted(self):
+        assert validate_fuel_levels([('E', 0), ('F', 100)]) == [
+            ('E', 0), ('F', 100)
+        ]
+
+    def test_returns_new_list(self):
+        levels = [('E', 0), ('F', 100)]
+        assert validate_fuel_levels(levels) is not levels
+
+    @pytest.mark.parametrize('levels', [
+        None,
+        'E:0,F:100',
+        {'E': 0, 'F': 100},
+        [],
+        [('F', 100)],
+        [('E', 0), ('F',)],
+        [('E', 0), ('F', 100, 1)],
+        [('E', 0), 'F'],
+        [('', 0), ('F', 100)],
+        [('   ', 0), ('F', 100)],
+        [(None, 0), ('F', 100)],
+        [(1, 0), ('F', 100)],
+        [('E', 0.5), ('F', 100)],
+        [('E', '50'), ('F', 100)],
+        [('E', True), ('F', 100)],
+        [('E', None), ('F', 100)],
+        [('E', -1), ('F', 100)],
+        [('E', 0), ('F', 101)],
+        [('E', 0), ('E', 50), ('F', 100)],
+        [('E', 0), (' E', 50), ('F', 100)],
+        [('E', 0), ('1/2', 50), ('half', 50), ('F', 100)],
+    ])
+    def test_invalid(self, levels):
+        with pytest.raises(ValueError):
+            validate_fuel_levels(levels)
+
+    def test_error_names_the_problem(self):
+        with pytest.raises(ValueError) as exc:
+            validate_fuel_levels([('E', 0), ('F', 150)])
+        assert '150' in str(exc.value)
+
+
+class TestFuelLevelsEnvVar:
+
+    def test_env_var_is_used(self):
+        res = import_settings_with_env('E:0, 1/2:50 ,F:100')
+        assert res.returncode == 0, res.stderr
+        assert json.loads(res.stdout.strip().splitlines()[-1]) == [
+            ['E', 0], ['1/2', 50], ['F', 100]
+        ]
+
+    @pytest.mark.parametrize('value', [
+        'E:0,F:150',
+        'F:100',
+        'E:0,E:50,F:100',
+        'E:x,F:100',
+        'E:0,1/2:50,half:50,F:100',
+    ])
+    def test_invalid_env_var_exits(self, value):
+        res = import_settings_with_env(value)
+        assert res.returncode != 0
+        assert 'ERROR: FUEL_LEVELS setting is invalid' in res.stderr

--- a/docs/source/app_usage.rst
+++ b/docs/source/app_usage.rst
@@ -74,6 +74,13 @@ the text, mainly because as far as I know I'm the only person in the world using
 this software. If anyone else uses it, I'll be happy to work to accomodate users
 of other languages or localities.
 
+The fuel level choices on the Fuel Log's Add Fuel Fill form can also be
+configured, for vehicles whose fuel gauge isn't marked in tenths, via
+:py:attr:`biweeklybudget.settings.FUEL_LEVELS` (for example
+``FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"`` as an environment variable).
+Each choice is a label paired with the percentage of a full tank it stands for,
+and that percentage is what is stored for the fill.
+
 Right now, regarding localization and currency formatting, please keep in mind
 the following caveats (which I'd be happy to fix if anyone needs it):
 

--- a/docs/source/http_api.rst
+++ b/docs/source/http_api.rst
@@ -727,8 +727,8 @@ Log a fuel fill and optionally create a :py:class:`~.Transaction` for the cost. 
 - ``vehicle`` *(integer, required)* - :py:class:`~.Vehicle` ID.
 - ``odometer_miles`` *(integer, required)* - Current odometer reading.
 - ``reported_miles`` *(integer, required)* - Miles reported by trip computer since last fill.
-- ``level_before`` *(integer, required)* - Fuel level before fill (0-100).
-- ``level_after`` *(integer, required)* - Fuel level after fill (0-100).
+- ``level_before`` *(integer, required)* - Fuel level before fill, as a percentage of a full tank (0-100); the web form sends one of the :py:attr:`~biweeklybudget.settings.FUEL_LEVELS` percentages.
+- ``level_after`` *(integer, required)* - Fuel level after fill, as a percentage of a full tank (0-100); the web form sends one of the :py:attr:`~biweeklybudget.settings.FUEL_LEVELS` percentages.
 - ``fill_location`` *(string, required)* - Location of the fill. Cannot be empty.
 - ``cost_per_gallon`` *(decimal, required)* - Cost per gallon. Must be positive.
 - ``total_cost`` *(decimal, required)* - Total cost. Must be positive and non-zero.

--- a/specs/20260912-073811-configurable-fuel-levels/checklists/requirements.md
+++ b/specs/20260912-073811-configurable-fuel-levels/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Configurable Fuel Levels
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- "Environment variable", "settings module" and "HTTP API" appear in the spec because they
+  are how this single-operator application is configured and used, not implementation
+  choices. The exact setting name and environment variable format are left to the plan.
+- The one scope decision a reviewer may want to revisit, one list for the whole
+  application rather than one per vehicle, is recorded in Assumptions.

--- a/specs/20260912-073811-configurable-fuel-levels/contracts/fuel-levels-setting.md
+++ b/specs/20260912-073811-configurable-fuel-levels/contracts/fuel-levels-setting.md
@@ -1,0 +1,66 @@
+# Contract: `FUEL_LEVELS` setting
+
+## Settings module
+
+```python
+FUEL_LEVELS = [
+    ('E', 0),
+    ('1/4', 25),
+    ('1/2', 50),
+    ('3/4', 75),
+    ('F', 100),
+]
+```
+
+Any sequence of 2-item lists or tuples is accepted; it is normalised to a list of
+`(label, percentage)` tuples. Default when unset:
+
+```python
+[('0/10', 0), ('1/10', 10), ('2/10', 20), ('3/10', 30), ('4/10', 40), ('5/10', 50),
+ ('6/10', 60), ('7/10', 70), ('8/10', 80), ('9/10', 90), ('10/10', 100)]
+```
+
+## Environment variable (overrides the settings module)
+
+```text
+FUEL_LEVELS=E:0,1/4:25,1/2:50,3/4:75,F:100
+```
+
+- Entries are separated by `,`. Each entry is `label:percentage`, split on its last `:`.
+- Whitespace around labels and percentages is ignored.
+- The percentage must be digits only.
+- Labels given this way cannot contain `,`.
+
+## Validation (either source)
+
+At import, `biweeklybudget.settings` exits with
+`SystemExit('ERROR: FUEL_LEVELS setting is invalid: <reason>')` if any of these hold:
+
+| Condition | Example |
+|-----------|---------|
+| fewer than two levels | `F:100` |
+| an entry is not a label/percentage pair | `E:0,1/2` (env); `[('E', 0, 1), …]` (module) |
+| empty label | `:0,F:100` |
+| percentage not an integer | `E:zero,F:100`; `('E', 0.5)`; `('E', True)` |
+| percentage outside 0–100 | `E:0,F:150` |
+| duplicated label | `E:0,E:50,F:100` |
+| duplicated percentage | `E:0,1/2:50,half:50,F:100` |
+
+## Fuel page (`GET /fuel`)
+
+The page defines a JavaScript global holding the validated list as JSON arrays:
+
+```javascript
+var FUEL_LEVELS = [["E", 0], ["1/4", 25], ["1/2", 50], ["3/4", 75], ["F", 100]];
+```
+
+The Add Fuel Fill modal's `fuel_frm_level_before` and `fuel_frm_level_after` selects each
+have one `<option value="{percentage}">{label}</option>` per entry, in list order, with the
+label shown as literal text. `level_before` preselects the lowest percentage and
+`level_after` the highest.
+
+## Unchanged
+
+- `POST /forms/fuel`: `level_before` and `level_after` are still integers, and are not
+  checked against `FUEL_LEVELS`.
+- The fuel log table and the fuel charts.

--- a/specs/20260912-073811-configurable-fuel-levels/data-model.md
+++ b/specs/20260912-073811-configurable-fuel-levels/data-model.md
@@ -1,0 +1,28 @@
+# Data Model: Configurable Fuel Levels
+
+No database change. No model, column, or migration is added or altered.
+
+## Fuel level option (setting, not stored)
+
+One entry of `settings.FUEL_LEVELS`.
+
+| Field | Type | Rules |
+|-------|------|-------|
+| label | string | Non-empty after stripping whitespace; unique within the list. Displayed literally. |
+| percentage | integer | Whole number 0–100 (a `bool` is not accepted); unique within the list. |
+
+The list:
+
+- is ordered, and has at least two entries;
+- is shown on the form in its configured order;
+- defaults to `0/10`→0, `1/10`→10 … `10/10`→100.
+
+The form's defaults are derived from the list, not configured separately. The starting
+level is the entry with the lowest percentage and the ending level the entry with the
+highest.
+
+## FuelFill (existing, unchanged)
+
+`level_before` and `level_after` stay `SmallInteger` columns holding a percentage of a full
+tank. A saved value is the `percentage` of the option chosen. Existing rows are not
+touched, and are displayed as percentages as before.

--- a/specs/20260912-073811-configurable-fuel-levels/plan.md
+++ b/specs/20260912-073811-configurable-fuel-levels/plan.md
@@ -1,0 +1,141 @@
+# Implementation Plan: Configurable Fuel Levels
+
+**Branch**: `robot-army/issue-208-fuel-log-configurable-fuel-levels` | **Date**: 2026-09-12 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/20260912-073811-configurable-fuel-levels/spec.md`
+
+## Summary
+
+A new setting, `FUEL_LEVELS`, holds an ordered list of `(label, percentage)` pairs. Its
+default reproduces today's `0/10` … `10/10` options. It can be set in the settings module or
+through a `FUEL_LEVELS="E:0,1/4:25,…"` environment variable. `biweeklybudget/settings.py`
+parses and validates it at import and exits with an error naming the setting if it's
+invalid. `fuel.html` exposes it to the page as a JSON global. `fuel.js` builds both fuel
+level selects from it in order, with labels escaped, preselecting the lowest percentage
+for the starting level and the highest for the ending level. Stored values stay
+percentages, so there is no model, migration, form-handler, table, or chart change.
+
+## Technical Context
+
+**Language/Version**: Python 3.14 (3.14.7); browser JavaScript (jQuery, ES5 style as in
+the existing `static/js`)
+
+**Primary Dependencies**: Flask 3.1 / Jinja2 3.1 (`tojson` filter). No new dependency.
+
+**Storage**: MariaDB, unchanged. No model, schema, or migration change (research R1).
+
+**Testing**: pytest. Unit tests (`tox -e py314`) cover parsing and validation, plus
+import-time behaviour in a subprocess. Selenium acceptance tests (`tox -e acceptance`)
+cover the page and form, with both the default list and a custom one (research R7). The
+full unit and acceptance suites must pass (Constitution II). `docs` must build
+(Constitution IV).
+
+**Target Platform**: Linux; the Flask app served locally or in Docker.
+
+**Project Type**: Flask/SQLAlchemy web application.
+
+**Performance Goals**: None. A list of about a dozen entries, validated once at startup.
+
+**Constraints**: With no configuration, behaviour must be identical to today (spec
+FR-003, SC-002). Stored level meaning must not change (FR-006). The HTTP API must not
+change.
+
+**Scale/Scope**: `settings.py` (one setting, two functions, import-time hook), one
+template line, one JS function, and the tests and docs for them.
+
+## Constitution Check
+
+*Constitution v2.1.1. Gate evaluated before Phase 0 and re-evaluated after Phase 1.*
+
+| Principle | Assessment | Status |
+|-----------|-----------|--------|
+| **I. Spec-Driven Change** (NON-NEGOTIABLE) | Spec written and validated, then this plan, then tasks, all before code. Work stays on the feature branch `robot-army/issue-208-fuel-log-configurable-fuel-levels`. The change is small enough to be a **single milestone (M1)**, so there is no inter-milestone boundary to cross. The maintainer's human approval is taken at the pull request, before merge. | PASS |
+| **II. The Test Gate** (NON-NEGOTIABLE) | Unit tests pin every validation rule (spec FR-007) and the default list (FR-003). A subprocess test proves an invalid env var aborts startup, and a valid one is used. Acceptance tests pin options, order, defaults and escaping for the default and a custom list, plus the percentages saved (FR-004–FR-006). The existing default-list acceptance assertions stay as they are, as a regression guard. The complete unit and acceptance suites MUST run to completion and pass. Timeouts get raised and re-run, never narrowed. `migrations`, `docker`, and `plaid` are not engaged but run in CI. New code stays pycodestyle/pyflakes-clean. | PASS |
+| **III. Reversible Migrations** | No change under `biweeklybudget/models/`; not engaged. | N/A |
+| **IV. Documentation Is Part Of The Change** | The `FUEL_LEVELS` docstring in `settings.py` (rendered by Sphinx as the settings reference) gives the format, env-var syntax, and an example. `docs/source/app_usage.rst`'s Fuel Log settings list gains the new setting. The `level_before`/`level_after` description in `docs/source/http_api.rst` is clarified. `README.rst` and `CLAUDE.md` don't list individual settings, so they need no change. The `docs` environment must build clean. Generated jsdoc pages are regenerated at release per the Release Checklist. | PASS |
+| **V. Escalate Instead Of Guessing** | Two scope choices were made with clear defaults rather than escalated: one global list, not one per vehicle; and percentages stored as today. Both are recorded in the spec's Assumptions and called out in the PR for the maintainer to overrule. | PASS |
+| **VI. Changelog Every Change; Release Only On Request** | One concise `CHANGES.rst` bullet under `Unreleased`, led by the issue link, naming the new setting. `version.py` is not touched; no tag. The one new Python file (a unit test module) carries the standard AGPL header. | PASS |
+| **Tech constraints** | No new dependency. The label is operator-supplied and rendered via `tojson` plus HTML escaping, so the setting can't inject script. That keeps the security posture unchanged. No financial-calculation code is touched, and acceptance tests use only the test database. | PASS |
+
+**Result: no violations. The Complexity Tracking table is therefore omitted.**
+
+Post-Phase-1 re-evaluation: the design adds one setting and two small pure functions in
+`settings.py` and one helper in `fuel.js`, with no new module or dependency. The
+Constitution Check still passes.
+
+## Design
+
+```text
+settings.py (import time)
+  FUEL_LEVELS = default tenths list
+  … SETTINGS_MODULE import may replace it …
+  if 'FUEL_LEVELS' in os.environ: FUEL_LEVELS = parse_fuel_levels(env)   ┐ ValueError →
+  FUEL_LEVELS = validate_fuel_levels(FUEL_LEVELS)                        ┘ SystemExit('ERROR: FUEL_LEVELS setting is invalid: …')
+
+fuel.html   var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};
+
+fuel.js     fuelLevelOptions(defaultValue) → [{value: pct, label: escaped label, selected}]
+            fuelModalDivForm(): addSelect(level_before, fuelLevelOptions(min pct))
+                                addSelect(level_after,  fuelLevelOptions(max pct))
+```
+
+- The env-var step runs after the settings module is imported, like the other env
+  overrides. Validation runs last, so both sources are checked (research R4).
+- `parse_fuel_levels` splits on `,`, then on each entry's last `:`, strips whitespace,
+  requires `\d+` percentages, and returns pairs. Validation of counts, ranges, and
+  uniqueness is left to `validate_fuel_levels`, so the rules live in one place.
+- `validate_fuel_levels` returns a new list of `(str(label).strip(), pct)` tuples.
+- `addSelect()` is used instead of `addLabelToValueSelect()` so integer-like labels keep
+  their order. Labels are escaped in `fuel.js` because `addSelect()` doesn't escape
+  (research R6).
+
+### Project Structure
+
+Documentation for this feature:
+
+```text
+specs/20260912-073811-configurable-fuel-levels/
+├── spec.md
+├── plan.md                        # this file
+├── research.md                    # Phase 0
+├── data-model.md                  # Phase 1
+├── quickstart.md                  # Phase 1
+├── contracts/
+│   └── fuel-levels-setting.md     # Phase 1: setting format, validation, page contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md                       # Phase 2, written by /speckit-tasks
+```
+
+Repository files this change touches:
+
+```text
+biweeklybudget/
+├── settings.py                                        # FUEL_LEVELS, parse/validate, import-time hook
+├── flaskapp/templates/fuel.html                       # FUEL_LEVELS JS global
+├── flaskapp/static/js/fuel.js                         # build level selects from FUEL_LEVELS
+├── tests/unit/test_settings_fuel_levels.py            # new: parse/validate + subprocess import
+└── tests/acceptance/flaskapp/views/test_fuel.py       # default global; custom list options/escaping/save
+docs/source/app_usage.rst                              # Fuel Log settings list
+docs/source/http_api.rst                               # level_before/level_after wording
+CHANGES.rst                                            # Unreleased entry
+```
+
+**Structure Decision**: the existing layout is kept. The one new file is a unit test module.
+
+## Milestones
+
+- **M1 — Setting, form, tests, and docs.** Add the setting and its parsing/validation with
+  unit tests. Expose it on the fuel page and build the selects from it, with acceptance
+  tests. Update the docs and `CHANGES.rst`. Run the Test Gate (unit, acceptance, docs),
+  record the results in the spec artifacts, then commit, push, and open the PR.
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| The default drifts from today's options, silently changing the form for everyone. | The existing `LEVEL_OPTS` acceptance assertions are kept unchanged. A unit test pins the default list value. |
+| A label containing `<`, `&` or `</script>` breaks the page or injects markup. | `tojson` in the template; HTML escaping in `fuel.js`. An acceptance test uses such a label and asserts it is shown literally. |
+| Integer-like labels (a numbered bar gauge) are shown out of order. | Options are built from an ordered array, not an object. An acceptance test uses numeric labels configured out of numeric order. |
+| An existing settings module defines `FUEL_LEVELS` for some other purpose and now fails validation. | Unlikely (the name is new). The error names the setting, so it is fixable at once. |
+| Testing import-time `SystemExit` pollutes the shared `settings` module. | Tested in a subprocess, never via `importlib.reload` (research R7). |

--- a/specs/20260912-073811-configurable-fuel-levels/plan.md
+++ b/specs/20260912-073811-configurable-fuel-levels/plan.md
@@ -130,6 +130,33 @@ CHANGES.rst                                            # Unreleased entry
   tests. Update the docs and `CHANGES.rst`. Run the Test Gate (unit, acceptance, docs),
   record the results in the spec artifacts, then commit, push, and open the PR.
 
+## Test Gate Results (M1, 2026-09-12)
+
+Run locally against MariaDB 10.4.7 (the CI image), Python 3.14.7:
+
+| Suite | Result |
+|-------|--------|
+| `tox -e py314` (unit + pycodestyle + pyflakes) | 936 passed, 6 skipped, 0 failed (`.pytest_cache` cleared first). Includes the 49 new tests in `test_settings_fuel_levels.py` |
+| `tox -e acceptance` | 797 passed, 24 skipped, 0 failed (17m42s). Includes the 4 new `TestFuelLevelsConfigured` tests, the extended `test_11`, and `TestFuelLogView::test_04_search`, which passed this time |
+| `tox -e docs` | Builds (exit 0). No warnings come from the new setting, functions, or doc edits. The warnings on `http_api.rst:722` (`FuelFormHandler`) and in the generated `jsdoc.fuel.rst` predate this change. |
+
+Coverage: `parse_fuel_levels()` and `validate_fuel_levels()` are fully covered. The
+four import-time lines that apply them (`settings.py` 402-403, env-var branch; 405-406,
+`SystemExit`) are exercised only by the subprocess tests in `TestFuelLevelsEnvVar`, which
+in-process coverage doesn't track. `settings.py` is 82% overall. Its other uncovered
+lines are the existing env-var loops, uncovered before this change too.
+
+Along the way:
+
+- **Baseline.** `test_fuel.py` passed 19/19 before any change.
+- **Red then green (unit).** The new unit module first failed to import (`cannot import name 'parse_fuel_levels'`), then passed 49/49 once T003/T007/T011 were in.
+- **Focused fuel acceptance run.** All 23 tests in `test_fuel.py` ran. The 4 new `TestFuelLevelsConfigured` tests passed, and so did the extended `test_11`. `TestFuelLogView::test_04_search` failed once: it read the fuel log table before the DataTables AJAX search for `v1 1` had applied, and saw all four unfiltered rows. That test and table aren't touched by this change. `TestFuelLogView` then passed 5/5 in each of three isolated re-runs with the change in place, so this is a timing race in that test, not a regression.
+- **Manual checks (quickstart).**
+  - Step 3: importing `biweeklybudget.settings` with `FUEL_LEVELS` set to `E:0,F:150`, `F:100`, or `E:0,E:50,F:100` exits 1 with `ERROR: FUEL_LEVELS setting is invalid: …` naming the problem. The quarters list is parsed in order.
+  - Step 2: `flask run` with `FUEL_LEVELS='E:0,1/4:25,1/2 </script>:50,3/4:75,F:100'` serves `/fuel` (HTTP 200) with `var FUEL_LEVELS = [["E", 0], ["1/4", 25], ["1/2 \u003c/script\u003e", 50], ["3/4", 75], ["F", 100]];`. The list arrives in order, and `tojson` escapes the `<` so the label can't break out of the script block. The in-browser form for a custom list is covered by `TestFuelLevelsConfigured`.
+  - Step 1 (the default) is covered by `test_11_fuel_populate_modal` and the unchanged `LEVEL_OPTS` assertions.
+- **Deviation from the file list above.** T005 said to reuse an existing HTML-escape helper if there was one. `escapeHtml()` existed, but only in `budgets_modal.js`, which the fuel page doesn't load. Rather than duplicate it, it moved to `custom.js`, which `base.html` loads on every page, and was removed from `budgets_modal.js`. Both pages that use it (`budgets.html`, `fuel.html`) extend `base.html`. The budgets acceptance tests cover the budgets page's use of it.
+
 ## Risks
 
 | Risk | Mitigation |

--- a/specs/20260912-073811-configurable-fuel-levels/quickstart.md
+++ b/specs/20260912-073811-configurable-fuel-levels/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: validating Configurable Fuel Levels
+
+## Prerequisites
+
+The MariaDB test container and environment variables from `CLAUDE.md` ("Test Database
+Setup for Development"), and tox from the main checkout's virtualenv.
+
+## Automated
+
+```bash
+tox -e py314        # parse/validate unit tests + subprocess import tests
+tox -e acceptance   # fuel page default list, custom list options/defaults/escaping, save
+tox -e docs         # FUEL_LEVELS documented; build must succeed
+```
+
+Focused runs while developing:
+
+```bash
+tox -e py314 -- biweeklybudget/tests/unit/test_settings_fuel_levels.py
+tox -e acceptance -- -k "fuel"
+```
+
+## Manual
+
+1. Start the app with no `FUEL_LEVELS` (`flask rundev`), open `/fuel`, then **Add Fill**.
+   Both level selects show `0/10` … `10/10`. Starting level is `0/10`, ending level is
+   `10/10` (spec User Story 2).
+2. Restart with `FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"`. The selects show those five
+   labels in order, with E and F preselected. Save a fill with 1/4 → F. The new row in the
+   fuel log shows 25% and 100% (spec User Story 1).
+3. Restart with `FUEL_LEVELS="E:0,F:150"`. The app exits with
+   `ERROR: FUEL_LEVELS setting is invalid: …` naming the problem (spec User Story 3).
+
+Contract details: [contracts/fuel-levels-setting.md](./contracts/fuel-levels-setting.md).

--- a/specs/20260912-073811-configurable-fuel-levels/research.md
+++ b/specs/20260912-073811-configurable-fuel-levels/research.md
@@ -1,0 +1,116 @@
+# Research: Configurable Fuel Levels
+
+All Technical Context items were known from the code; there were no NEEDS CLARIFICATION
+markers. This file records the design decisions and the alternatives rejected.
+
+## R1. Where the option list lives today
+
+**Finding**: The eleven options exist in exactly one place, as two identical object
+literals in `fuelModalDivForm()` in `biweeklybudget/flaskapp/static/js/fuel.js`, passed to
+`FormBuilder.addLabelToValueSelect()` with defaults `0` (before) and `100` (after). The
+server (`FuelFormHandler` in `flaskapp/views/fuel.py`) only checks that each level is an
+integer. The model (`FuelFill.level_before`/`level_after`) is a `SmallInteger` documented as
+a percentage 0–100. Nothing computes with the levels (no MPG or chart code reads them); the
+fuel log table renders them as `N%`.
+
+**Consequence**: The change is a new setting, a template line to expose it, and a JS change.
+No model, migration, or form-handler change is needed.
+
+## R2. Setting shape: ordered list of `(label, percentage)` pairs
+
+**Decision**: `settings.FUEL_LEVELS`, a list of 2-item `(label, percentage)` sequences,
+defaulting to `[('0/10', 0), ('1/10', 10), … ('10/10', 100)]`.
+
+**Rationale**: A list keeps the configured order (spec FR-004) and allows any labels.
+Pairing each label with a percentage keeps the stored meaning of a level unchanged
+(FR-006), so old and new fills stay comparable.
+
+**Alternatives rejected**:
+- *A `dict` of label → percentage*: order is preserved in Python, but once serialised to a
+  JavaScript object, integer-like keys (`"0"`, `"1"` … for a bar gauge) are re-ordered
+  ahead of the others. A list of pairs has no such trap.
+- *A number of divisions (e.g. `8` for eighths)*: can't express labels like `E`/`F`, or
+  gauges that are not evenly divided.
+- *Store the label*: see spec Assumptions; makes fills logged under different lists
+  incomparable and needs a migration.
+
+## R3. Environment variable format
+
+**Decision**: `FUEL_LEVELS` as comma-separated `label:percentage` entries, for example
+`FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"`. Each entry is split on its **last** colon,
+so a label may itself contain a colon. Whitespace around labels and percentages is
+stripped. Labels given by environment variable cannot contain commas; a settings module
+can use any label.
+
+**Rationale**: Every other setting can be given as an environment variable (spec FR-002,
+`getting_started.rst`), and the Docker image is configured that way. This format is easy
+to type in a Docker env file, unlike JSON with its nested quotes.
+
+**Alternatives rejected**: JSON (awkward quoting in env files and shell); `label=percent`
+(`=` in a value is confusing in `KEY=VALUE` env files).
+
+## R4. Validation at import, failing with `SystemExit`
+
+**Decision**: Two module-level functions in `biweeklybudget/settings.py`:
+`parse_fuel_levels(value)` (env string → list of pairs) and
+`validate_fuel_levels(levels)` (checks and normalises the list, whatever its source). Both
+raise `ValueError` with a specific reason. At import, the module parses the env var if set,
+then validates the final value, turning any `ValueError` into
+`SystemExit('ERROR: FUEL_LEVELS setting is invalid: <reason>')`.
+
+Rules (spec FR-007): at least two levels; each is a 2-item list or tuple; the label is a
+non-empty string after stripping whitespace; the percentage is an `int` (not `bool`) from
+0 to 100; labels are unique; percentages are unique. In the env var, the percentage must
+be all digits (`\d+`), matching the strictness of the existing `_INT_VARS` parsing.
+
+**Rationale**: Invalid `_INT_VARS`, `_DATE_VARS`, `LOCALE_NAME`, and `CURRENCY_CODE` values
+already abort startup with `SystemExit('ERROR: ...')`. Validating the settings-module value
+too means a typo there is caught the same way. Pure functions can be unit-tested directly;
+an import-time check can be tested in a subprocess without reloading the shared module.
+
+**Why duplicates are rejected**: two options with the same percentage would be
+indistinguishable once saved; two with the same label would be indistinguishable on the
+form.
+
+## R5. Getting the list to the browser
+
+**Decision**: `fuel.html` adds `var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};` next
+to the existing `fuel_budget_id` global. The `settings` context processor already exposes
+every setting to templates.
+
+**Rationale**: Only the fuel page uses it, so it goes in that page's template rather than
+`base.html`. Jinja's `tojson` escapes `<`, `>`, `&` and `'`, so no label can break out of
+the `<script>` block. Tuples serialise as JSON arrays.
+
+## R6. Building the selects in `fuel.js`
+
+**Decision**: Build an ordered array of `{value, label, selected}` from `FUEL_LEVELS` and
+pass it to `FormBuilder.addSelect()`, which already takes an ordered array. The starting
+select preselects the lowest percentage, the ending select the highest. Labels are
+HTML-escaped before being handed to `addSelect()`, which concatenates labels into HTML
+unescaped.
+
+**Rationale**: `addLabelToValueSelect()` takes an object and would re-order integer-like
+labels (R2). Escaping in `fuel.js` rather than in `addSelect()` avoids changing how every
+other form in the application renders its options. Account and budget names pass through
+`addSelect()` too, and changing that is out of scope.
+
+## R7. Testing a non-default list in the browser
+
+**Finding**: The acceptance tests' `testflask` fixture is session-scoped and forks a live
+server, so patching `settings` in the test process doesn't reach it. The test settings
+module must keep the default list, so the existing default-behaviour assertions keep
+guarding FR-003.
+
+**Decision**:
+- Settings parsing/validation: unit tests of the two functions, plus subprocess imports of
+  `biweeklybudget.settings` with `FUEL_LEVELS` set in the environment (valid → value
+  parsed; invalid → non-zero exit and an error naming `FUEL_LEVELS`).
+- Server → page: an acceptance test reads the `FUEL_LEVELS` global from the rendered `/fuel`
+  page and checks it equals the default list.
+- Page → form → database, non-default: acceptance tests replace the page's `FUEL_LEVELS`
+  global via Selenium before opening the modal, then check options, order, defaults and
+  literal (escaped) labels, and save a fill and check the recorded percentages.
+
+Together these cover each link of the chain (setting → page → form → stored value) with
+both default and non-default lists.

--- a/specs/20260912-073811-configurable-fuel-levels/spec.md
+++ b/specs/20260912-073811-configurable-fuel-levels/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Configurable Fuel Levels
+
+**Feature Branch**: `robot-army/issue-208-fuel-log-configurable-fuel-levels`
+
+**Created**: 2026-09-12
+
+**Status**: Draft
+
+**Input**: GitHub issue [#208](https://github.com/jantman/biweeklybudget/issues/208) — "Fuel Log - Configurable fuel levels"
+
+## Context
+
+When a fuel fill is logged, the Add Fuel Fill form asks for the starting and ending fuel
+level. Both are chosen from a fixed list of eleven options, `0/10` through `10/10`. Each
+option stands for a percentage of a full tank (0, 10, 20 … 100), and that percentage is
+what gets recorded for the fill.
+
+Most fuel gauges are not marked in tenths. Common markings are eighths (E, 1/8, 1/4 …
+F), quarters, or a bar display with some other number of segments. The owner of such a
+car has to convert the gauge reading to the nearest tenth every time they log a fill, and
+the result is inaccurate. The issue asks for the list of levels to be configurable.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Log a fill using my own gauge's markings (Priority: P1)
+
+The operator's car has a gauge marked E, 1/4, 1/2, 3/4, F. They configure the application
+with those five levels, each paired with the percentage of a full tank it represents. When
+they next open Add Fuel Fill, both fuel level selects show exactly those five choices, in
+the configured order. The starting level defaults to the emptiest level and the ending
+level defaults to the fullest. They pick what the gauge showed and save. The fill is
+recorded with the percentage paired with each chosen label.
+
+**Why this priority**: This is the whole of the issue.
+
+**Independent Test**: Configure a non-default list of levels, open Add Fuel Fill, check
+the options and defaults in both selects, then save a fill and check the recorded levels.
+
+**Acceptance Scenarios**:
+
+1. **Given** the levels are configured as E=0, 1/4=25, 1/2=50, 3/4=75, F=100, **When** the
+   Add Fuel Fill form opens, **Then** both the starting and ending level selects list
+   exactly E, 1/4, 1/2, 3/4, F in that order, and no other options.
+2. **Given** the same configuration, **When** the form opens, **Then** the starting level
+   is preselected as E (the lowest percentage) and the ending level as F (the highest
+   percentage).
+3. **Given** the same configuration, **When** the operator chooses starting level 1/4 and
+   ending level F and saves, **Then** the fill is recorded with a starting level of 25 and
+   an ending level of 100.
+
+---
+
+### User Story 2 - Nothing changes for an operator who configures nothing (Priority: P1)
+
+The operator upgrades and does not configure fuel levels. The Add Fuel Fill form behaves
+exactly as it did before: eleven options `0/10` to `10/10` meaning 0 to 100 percent,
+starting level preselected as `0/10`, ending level preselected as `10/10`.
+
+**Why this priority**: Equally essential. An upgrade must not change the form, or the
+meaning of what it records, for anyone who has not asked for a change.
+
+**Independent Test**: With no fuel level configuration, open Add Fuel Fill and compare
+the options, their recorded values and the defaults with the current behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** no fuel level configuration, **When** the form opens, **Then** both selects
+   list `0/10`, `1/10` … `10/10`, recording 0, 10 … 100, with `0/10` preselected for the
+   starting level and `10/10` for the ending level.
+
+---
+
+### User Story 3 - A mistake in the configuration is reported, not silently used (Priority: P2)
+
+The operator sets the levels through an environment variable and makes a typo, such as a
+missing percentage or a percentage of 150. The application refuses to start and prints a
+message naming the fuel level setting and what is wrong with it. It does not start with a
+broken or partial list.
+
+**Why this priority**: A malformed list would otherwise produce a form that records wrong
+numbers into the fuel log, or no usable form at all. Failing at startup is how the other
+settings already behave, and it is cheaper to notice.
+
+**Independent Test**: Start the application with each kind of invalid value and confirm it
+exits with an error naming the setting.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fuel level list with a percentage outside 0–100, a non-integer percentage,
+   an empty label, a duplicated label, a duplicated percentage, or fewer than two levels,
+   **When** the application starts, **Then** it exits with an error message that names
+   the fuel level setting and describes the problem.
+
+### Edge Cases
+
+- **Fractions that are not whole percentages**, such as 1/8 (12.5%): percentages are
+  whole numbers, so the operator chooses the rounding (for example 1/8=13). The fuel log
+  has always stored whole percentages, so this loses nothing that was stored before.
+- **Levels configured out of order**: they are shown in the order configured. The defaults
+  still use the lowest and highest percentages, wherever those appear in the list.
+- **Existing fills logged before the list was changed**: they keep their recorded
+  percentages, and the fuel log table and charts keep showing them as percentages. Nothing
+  is converted.
+- **Labels containing characters with meaning in a web page** (such as `<` or `&`): they
+  are displayed as the literal text configured.
+- **Fills submitted directly to the HTTP API**: unchanged. The API still accepts integer
+  levels, and does not require them to be one of the configured values, as today.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The operator MUST be able to configure the fuel levels offered on the Add
+  Fuel Fill form as an ordered list, each entry pairing a display label with the whole
+  percentage of a full tank (0–100) it represents.
+- **FR-002**: The list MUST be configurable in the settings module and through an
+  environment variable, like the other Fuel Log settings.
+- **FR-003**: When no list is configured, the default MUST reproduce the current options
+  exactly: labels `0/10` through `10/10` for 0, 10 … 100 percent.
+- **FR-004**: The starting and ending fuel level selects MUST both offer exactly the
+  configured levels, in the configured order.
+- **FR-005**: The starting level MUST default to the configured level with the lowest
+  percentage, and the ending level to the level with the highest percentage.
+- **FR-006**: Saving a fill MUST record, for each of the starting and ending levels, the
+  percentage paired with the chosen label. The stored meaning of a level (a percentage of
+  a full tank) MUST NOT change.
+- **FR-007**: The application MUST refuse to start, with an error naming the fuel level
+  setting, if the configured list has fewer than two levels, an empty or duplicated label,
+  a duplicated percentage, or a percentage that is not a whole number from 0 to 100.
+- **FR-008**: The new setting MUST be documented where the other Fuel Log settings are
+  documented, including the environment variable format and an example for a gauge that
+  is not marked in tenths.
+
+### Key Entities
+
+- **Fuel level option**: a label as marked on the operator's gauge (for example `1/4` or
+  `E`), paired with the whole percentage of a full tank that the label represents. The
+  configured list of these is a setting. Only the percentage is stored with a fill, as
+  today, so no stored data changes shape.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator whose gauge is marked in eighths, quarters or any other division
+  can log a fill by picking the label that matches the gauge, with no mental conversion to
+  tenths.
+- **SC-002**: With no configuration, 100% of the Add Fuel Fill form's level options,
+  recorded values and defaults are identical to those before the change.
+- **SC-003**: 100% of the invalid configurations listed in FR-007 are rejected at startup
+  with a message that names the setting; none produce a form.
+- **SC-004**: Every fill logged before the change still shows the same levels in the fuel
+  log afterwards.
+
+## Assumptions
+
+- **One list for the whole application, not per vehicle.** The issue asks for "a
+  configurable list of values", and the other Fuel Log settings (units and abbreviations)
+  are global. A household whose vehicles have differently marked gauges would want a list
+  per vehicle, but that needs a schema change and a vehicle-editing UI change. It is out
+  of scope here and can be added later without undoing this work.
+- **Levels stay stored as percentages.** Keeping the stored value a percentage of a full
+  tank means existing data, the fuel log table and the charts keep their meaning, and no
+  migration is needed. The alternative of storing the label would make fills logged under
+  different lists incomparable.
+- **The fuel log table keeps showing percentages.** The issue is about input. Showing
+  labels in the table would make old fills, logged under a different list, display
+  differently from new ones.
+- **The HTTP API is unchanged.** It already accepts any integer level. Restricting it to
+  the configured list would break existing API callers and is not asked for.

--- a/specs/20260912-073811-configurable-fuel-levels/spec.md
+++ b/specs/20260912-073811-configurable-fuel-levels/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-09-12
 
-**Status**: Draft
+**Status**: Complete
 
 **Input**: GitHub issue [#208](https://github.com/jantman/biweeklybudget/issues/208) — "Fuel Log - Configurable fuel levels"
 

--- a/specs/20260912-073811-configurable-fuel-levels/tasks.md
+++ b/specs/20260912-073811-configurable-fuel-levels/tasks.md
@@ -50,6 +50,7 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 - [X] T005 [P] In `biweeklybudget/flaskapp/static/js/fuel.js`:
   - Add a JSDoc-commented `fuelLevelOptions(selectedValue)` that returns an Array of `{value: pct, label: <HTML-escaped label>, selected: pct == selectedValue}` built from the global `FUEL_LEVELS` in order. Reuse an existing HTML-escape helper from `static/js` if there is one; otherwise add a small local one escaping `& < > " '`.
   - In `fuelModalDivForm()`, compute the min and max percentage in `FUEL_LEVELS`. Replace the two `addLabelToValueSelect(...)` calls for `fuel_frm_level_before`/`fuel_frm_level_after` with `addSelect(id, name, label, fuelLevelOptions(min|max))`, keeping the same ids, names and labels.
+  - Done as: the existing `escapeHtml()` was only in `budgets_modal.js`, which the fuel page doesn't load. So it moved to `custom.js`, which every page loads via `base.html`, instead of being duplicated (see plan.md, Test Gate Results).
 
 **Checkpoint**: T002 passes. With no configuration the form should look exactly as before (verified in US2).
 
@@ -118,14 +119,14 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 - [X] T012 [P] In `docs/source/app_usage.rst`, in the Fuel Log settings list (~line 66), add a bullet for `:py:attr:`biweeklybudget.settings.FUEL_LEVELS``, which sets the fuel level choices on the Add Fuel Fill form. Adjust the following sentence, which says these settings only affect display of units, so it stays accurate.
 - [X] T013 [P] In `docs/source/http_api.rst` (~line 730), change the `level_before`/`level_after` descriptions to say the value is a percentage of a full tank (0-100), normally one of the `FUEL_LEVELS` setting's percentages.
 - [X] T014 [P] In `CHANGES.rst`, add one concise bullet at the top of `Unreleased`, led by the `Issue #208` link: the fuel level choices on the Add Fuel Fill form are now configurable via the new `FUEL_LEVELS` setting; the default is unchanged. Add a short sub-bullet with the env-var format example. Do not touch `biweeklybudget/version.py`.
-- [ ] T015 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
+- [X] T015 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
   - `tox -e py314`, which also covers pycodestyle and pyflakes.
   - `tox -e acceptance`.
   - `tox -e docs`.
 
   Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged and run in CI.
-- [ ] T016 Manually walk through `quickstart.md` steps 1–3 against `flask rundev`, or record why that wasn't possible.
-- [ ] T017 Record results in the spec artifacts: set `spec.md` Status to Complete, mark the tasks here done, and add a "Test Gate Results" section to `plan.md`. Commit with the prefix `Configurable Fuel Levels - M1.x`.
+- [X] T016 Manually walk through `quickstart.md` steps 1–3 against `flask rundev`, or record why that wasn't possible.
+- [X] T017 Record results in the spec artifacts: set `spec.md` Status to Complete, mark the tasks here done, and add a "Test Gate Results" section to `plan.md`. Commit with the prefix `Configurable Fuel Levels - M1.x`.
 - [ ] T018 Push the branch to `origin` and open the pull request, following `.github/PULL_REQUEST_TEMPLATE.md` and surfacing the spec's Assumptions (global list, percentages stored) for the maintainer. Then monitor CI and answer reviews until Claude's review says "No issues found" and Copilot's, if present, recommends approval.
 
 ---

--- a/specs/20260912-073811-configurable-fuel-levels/tasks.md
+++ b/specs/20260912-073811-configurable-fuel-levels/tasks.md
@@ -127,7 +127,7 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
   Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged and run in CI.
 - [X] T016 Manually walk through `quickstart.md` steps 1–3 against `flask rundev`, or record why that wasn't possible.
 - [X] T017 Record results in the spec artifacts: set `spec.md` Status to Complete, mark the tasks here done, and add a "Test Gate Results" section to `plan.md`. Commit with the prefix `Configurable Fuel Levels - M1.x`.
-- [ ] T018 Push the branch to `origin` and open the pull request, following `.github/PULL_REQUEST_TEMPLATE.md` and surfacing the spec's Assumptions (global list, percentages stored) for the maintainer. Then monitor CI and answer reviews until Claude's review says "No issues found" and Copilot's, if present, recommends approval.
+- [X] T018 Push the branch to `origin` and open the pull request, following `.github/PULL_REQUEST_TEMPLATE.md` and surfacing the spec's Assumptions (global list, percentages stored) for the maintainer. Then monitor CI and answer reviews until Claude's review says "No issues found" and Copilot's, if present, recommends approval.
 
 ---
 

--- a/specs/20260912-073811-configurable-fuel-levels/tasks.md
+++ b/specs/20260912-073811-configurable-fuel-levels/tasks.md
@@ -36,7 +36,7 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 **Purpose**: A working test environment, so the new tests can be seen to fail and then pass.
 
-- [ ] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), using tox from the main checkout's venv. Confirm a green baseline for the fuel acceptance tests with `tox -e acceptance -- biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py`, output redirected to the scratchpad.
+- [X] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), using tox from the main checkout's venv. Confirm a green baseline for the fuel acceptance tests with `tox -e acceptance -- biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py`, output redirected to the scratchpad.
 
 ---
 
@@ -44,10 +44,10 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 **Purpose**: The setting exists with today's values as its default, reaches the page, and the form is built from it.
 
-- [ ] T002 Create `biweeklybudget/tests/unit/test_settings_fuel_levels.py` with the standard AGPL header (copy from an existing test module). Add `TestFuelLevelsDefault.test_default`, asserting `settings.FUEL_LEVELS == [('%d/10' % i, i * 10) for i in range(11)]`. The test settings module does not set `FUEL_LEVELS`, so this pins the default. Confirm it fails (no attribute) before T003.
-- [ ] T003 In `biweeklybudget/settings.py`, after `FUEL_ECO_ABBREVIATION`, add `FUEL_LEVELS = [('%d/10' % i, i * 10) for i in range(11)]` with a `#:` docstring. The docstring covers: an ordered list of `(label, percentage)` pairs offered as the Add Fuel Fill form's starting and ending fuel levels; the percentage (whole number 0–100) is what is stored; the form shows them in order and defaults to the lowest and highest percentage; the env-var syntax `label:percentage` separated by commas, split on the last colon, with no commas in labels; an example `E:0,1/4:25,1/2:50,3/4:75,F:100`; the validation rules from `contracts/fuel-levels-setting.md`; and a pointer to `:ref:`Currency Formatting and Localization <app_usage.l10n>``.
-- [ ] T004 [P] In `biweeklybudget/flaskapp/templates/fuel.html`, in the inline `<script>` that sets `fuel_budget_id` (~line 155), add `var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};`.
-- [ ] T005 [P] In `biweeklybudget/flaskapp/static/js/fuel.js`:
+- [X] T002 Create `biweeklybudget/tests/unit/test_settings_fuel_levels.py` with the standard AGPL header (copy from an existing test module). Add `TestFuelLevelsDefault.test_default`, asserting `settings.FUEL_LEVELS == [('%d/10' % i, i * 10) for i in range(11)]`. The test settings module does not set `FUEL_LEVELS`, so this pins the default. Confirm it fails (no attribute) before T003.
+- [X] T003 In `biweeklybudget/settings.py`, after `FUEL_ECO_ABBREVIATION`, add `FUEL_LEVELS = [('%d/10' % i, i * 10) for i in range(11)]` with a `#:` docstring. The docstring covers: an ordered list of `(label, percentage)` pairs offered as the Add Fuel Fill form's starting and ending fuel levels; the percentage (whole number 0–100) is what is stored; the form shows them in order and defaults to the lowest and highest percentage; the env-var syntax `label:percentage` separated by commas, split on the last colon, with no commas in labels; an example `E:0,1/4:25,1/2:50,3/4:75,F:100`; the validation rules from `contracts/fuel-levels-setting.md`; and a pointer to `:ref:`Currency Formatting and Localization <app_usage.l10n>``.
+- [X] T004 [P] In `biweeklybudget/flaskapp/templates/fuel.html`, in the inline `<script>` that sets `fuel_budget_id` (~line 155), add `var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};`.
+- [X] T005 [P] In `biweeklybudget/flaskapp/static/js/fuel.js`:
   - Add a JSDoc-commented `fuelLevelOptions(selectedValue)` that returns an Array of `{value: pct, label: <HTML-escaped label>, selected: pct == selectedValue}` built from the global `FUEL_LEVELS` in order. Reuse an existing HTML-escape helper from `static/js` if there is one; otherwise add a small local one escaping `& < > " '`.
   - In `fuelModalDivForm()`, compute the min and max percentage in `FUEL_LEVELS`. Replace the two `addLabelToValueSelect(...)` calls for `fuel_frm_level_before`/`fuel_frm_level_after` with `addSelect(id, name, label, fuelLevelOptions(min|max))`, keeping the same ids, names and labels.
 
@@ -63,15 +63,15 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 ### Tests for User Story 1
 
-- [ ] T006 [US1] In `test_settings_fuel_levels.py`, add `TestParseFuelLevels`:
+- [X] T006 [US1] In `test_settings_fuel_levels.py`, add `TestParseFuelLevels`:
   - `E:0,1/4:25,1/2:50,3/4:75,F:100` → the five pairs in order.
   - Whitespace around labels and percentages is stripped (` E : 0 , F:100 `).
   - A label containing a colon splits on the last colon (`a:b:50` → `('a:b', 50)`).
   - A non-digit percentage (`E:x`, `E:-5`, `E:1.5`) and an entry with no colon raise `ValueError`.
 
   Also add `TestFuelLevelsEnvVar.test_env_var_is_used`, which runs `subprocess.run([sys.executable, '-c', 'import json; from biweeklybudget import settings; print(json.dumps(settings.FUEL_LEVELS))'], env={**os.environ, 'FUEL_LEVELS': 'E:0,1/2:50,F:100', 'DB_CONNSTRING': os.environ.get('DB_CONNSTRING', 'mysql+pymysql://u:p@127.0.0.1/x')}, capture_output=True, text=True)`. Assert return code 0 and the last stdout line parses to `[['E', 0], ['1/2', 50], ['F', 100]]`. Confirm these fail before T007.
-- [ ] T007 [US1] In `biweeklybudget/settings.py`, add module-level `parse_fuel_levels(value)` with a docstring, per research R3. Split on `,`; each entry is `rpartition(':')`, and an empty separator means `ValueError`. Strip both parts. The percentage must match `^\d+$`, else `ValueError` naming the offending entry. Return a list of `(label, int(pct))` tuples. After the `_DATE_VARS` env loop, add: `if 'FUEL_LEVELS' in os.environ: FUEL_LEVELS = parse_fuel_levels(os.environ['FUEL_LEVELS'])`, converting `ValueError` to `SystemExit('ERROR: FUEL_LEVELS setting is invalid: %s' % ex)`. T006 must pass.
-- [ ] T008 [US1] In `test_fuel.py`, append a new acceptance class `TestFuelLevelsConfigured` (same base class and `@pytest.mark.acceptance` / `usefixtures` pattern as the existing classes, checking how class-level DB refresh works so that fill IDs are predictable). Its tests:
+- [X] T007 [US1] In `biweeklybudget/settings.py`, add module-level `parse_fuel_levels(value)` with a docstring, per research R3. Split on `,`; each entry is `rpartition(':')`, and an empty separator means `ValueError`. Strip both parts. The percentage must match `^\d+$`, else `ValueError` naming the offending entry. Return a list of `(label, int(pct))` tuples. After the `_DATE_VARS` env loop, add: `if 'FUEL_LEVELS' in os.environ: FUEL_LEVELS = parse_fuel_levels(os.environ['FUEL_LEVELS'])`, converting `ValueError` to `SystemExit('ERROR: FUEL_LEVELS setting is invalid: %s' % ex)`. T006 must pass.
+- [X] T008 [US1] In `test_fuel.py`, append a new acceptance class `TestFuelLevelsConfigured` (same base class and `@pytest.mark.acceptance` / `usefixtures` pattern as the existing classes, checking how class-level DB refresh works so that fill IDs are predictable). Its tests:
   - `test_1_custom_levels`: load `/fuel` and run `selenium.execute_script("FUEL_LEVELS = [['E', 0], ['1/4', 25], ['1/2', 50], ['3/4', 75], ['F', 100]];")`. Open **Add Fill**. Assert both selects' `[value, text]` options are exactly `[['0','E'],['25','1/4'],['50','1/2'],['75','3/4'],['100','F']]`, with `level_before` selected `0` and `level_after` selected `100`.
   - `test_2_add_fill`: with the same override, fill the form like `test_12_fuel_add_no_trans` (add-transaction unchecked), choosing `1/4` → `F`. Save, and confirm the success message.
   - `test_3_verify_db`: the new `FuelFill` has `level_before == 25` and `level_after == 100`.
@@ -87,7 +87,7 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 **Independent Test**: The existing default-list acceptance assertions pass unchanged, plus the check below.
 
-- [ ] T009 [US2] In `test_fuel.py`, leave `LEVEL_OPTS` and the `test_11_fuel_populate_modal` / `test_12` / `test_14` level assertions exactly as they are, so they guard FR-003. In `test_11_fuel_populate_modal`, after loading `/fuel`, add `assert selenium.execute_script('return FUEL_LEVELS;') == [[l, int(v)] for v, l in LEVEL_OPTS]`. This proves the server renders the default setting into the page. Run the fuel acceptance tests; all existing and new ones pass.
+- [X] T009 [US2] In `test_fuel.py`, leave `LEVEL_OPTS` and the `test_11_fuel_populate_modal` / `test_12` / `test_14` level assertions exactly as they are, so they guard FR-003. In `test_11_fuel_populate_modal`, after loading `/fuel`, add `assert selenium.execute_script('return FUEL_LEVELS;') == [[l, int(v)] for v, l in LEVEL_OPTS]`. This proves the server renders the default setting into the page. Run the fuel acceptance tests; all existing and new ones pass.
 
 **Checkpoint**: US1 and US2 pass.
 
@@ -101,13 +101,13 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 ### Tests for User Story 3
 
-- [ ] T010 [US3] In `test_settings_fuel_levels.py`, add `TestValidateFuelLevels`:
+- [X] T010 [US3] In `test_settings_fuel_levels.py`, add `TestValidateFuelLevels`:
   - Valid lists of tuples and of lists return a list of `(label, pct)` tuples with labels stripped.
   - Each of these raises `ValueError`, parametrized: fewer than two levels (0 and 1 entries); an entry that isn't a 2-item list/tuple (`('E',)`, `('E', 0, 1)`, a bare string); an empty or whitespace label; a non-str label (`None`); percentage `0.5`, `'50'`, `True`; percentage `-1` or `101`; a duplicated label; a duplicated percentage; a non-list value (`None`, `'E:0,F:100'`).
   - The boundaries 0 and 100 are accepted.
 
   Add `TestFuelLevelsEnvVar.test_invalid_env_var_exits`, parametrized over `E:0,F:150`, `F:100`, `E:0,E:50,F:100`, `E:x,F:100` and using the T006 subprocess helper. Assert a non-zero return code and `'FUEL_LEVELS setting is invalid'` in stderr. Confirm these fail before T011.
-- [ ] T011 [US3] In `biweeklybudget/settings.py`, add module-level `validate_fuel_levels(levels)` with a docstring implementing the rules in `contracts/fuel-levels-setting.md` (research R4). It returns a new normalised list and raises `ValueError` with a specific reason. After the env-var step from T007, and before the `_REQUIRED_VARS` check, run `FUEL_LEVELS = validate_fuel_levels(FUEL_LEVELS)`, converting `ValueError` to the same `SystemExit` message. T010 and all earlier tests must pass.
+- [X] T011 [US3] In `biweeklybudget/settings.py`, add module-level `validate_fuel_levels(levels)` with a docstring implementing the rules in `contracts/fuel-levels-setting.md` (research R4). It returns a new normalised list and raises `ValueError` with a specific reason. After the env-var step from T007, and before the `_REQUIRED_VARS` check, run `FUEL_LEVELS = validate_fuel_levels(FUEL_LEVELS)`, converting `ValueError` to the same `SystemExit` message. T010 and all earlier tests must pass.
 
 **Checkpoint**: All three stories pass.
 
@@ -115,9 +115,9 @@ one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T012 [P] In `docs/source/app_usage.rst`, in the Fuel Log settings list (~line 66), add a bullet for `:py:attr:`biweeklybudget.settings.FUEL_LEVELS``, which sets the fuel level choices on the Add Fuel Fill form. Adjust the following sentence, which says these settings only affect display of units, so it stays accurate.
-- [ ] T013 [P] In `docs/source/http_api.rst` (~line 730), change the `level_before`/`level_after` descriptions to say the value is a percentage of a full tank (0-100), normally one of the `FUEL_LEVELS` setting's percentages.
-- [ ] T014 [P] In `CHANGES.rst`, add one concise bullet at the top of `Unreleased`, led by the `Issue #208` link: the fuel level choices on the Add Fuel Fill form are now configurable via the new `FUEL_LEVELS` setting; the default is unchanged. Add a short sub-bullet with the env-var format example. Do not touch `biweeklybudget/version.py`.
+- [X] T012 [P] In `docs/source/app_usage.rst`, in the Fuel Log settings list (~line 66), add a bullet for `:py:attr:`biweeklybudget.settings.FUEL_LEVELS``, which sets the fuel level choices on the Add Fuel Fill form. Adjust the following sentence, which says these settings only affect display of units, so it stays accurate.
+- [X] T013 [P] In `docs/source/http_api.rst` (~line 730), change the `level_before`/`level_after` descriptions to say the value is a percentage of a full tank (0-100), normally one of the `FUEL_LEVELS` setting's percentages.
+- [X] T014 [P] In `CHANGES.rst`, add one concise bullet at the top of `Unreleased`, led by the `Issue #208` link: the fuel level choices on the Add Fuel Fill form are now configurable via the new `FUEL_LEVELS` setting; the default is unchanged. Add a short sub-bullet with the env-var format example. Do not touch `biweeklybudget/version.py`.
 - [ ] T015 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
   - `tox -e py314`, which also covers pycodestyle and pyflakes.
   - `tox -e acceptance`.

--- a/specs/20260912-073811-configurable-fuel-levels/tasks.md
+++ b/specs/20260912-073811-configurable-fuel-levels/tasks.md
@@ -1,0 +1,181 @@
+---
+
+description: "Task list for Configurable Fuel Levels"
+---
+
+# Tasks: Configurable Fuel Levels
+
+**Input**: Design documents from `specs/20260912-073811-configurable-fuel-levels/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/fuel-levels-setting.md, quickstart.md
+
+**Tests**: Included. Constitution II requires new code to be covered by valid tests, and
+the spec's success criteria SC-002 and SC-003 are verified by them.
+
+**Organization**: Grouped by user story. The setting's default and the JS that builds the
+selects from it are shared by every story, so they are Foundational. The whole feature is
+one milestone (M1). Commit prefix: `Configurable Fuel Levels - M1.x`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+## Path Conventions
+
+- Settings: `biweeklybudget/settings.py`
+- Fuel page template: `biweeklybudget/flaskapp/templates/fuel.html`
+- Fuel page JS: `biweeklybudget/flaskapp/static/js/fuel.js`
+- New unit tests: `biweeklybudget/tests/unit/test_settings_fuel_levels.py`
+- Acceptance tests: `biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py`
+- Docs: `docs/source/app_usage.rst`, `docs/source/http_api.rst`; changelog `CHANGES.rst`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: A working test environment, so the new tests can be seen to fail and then pass.
+
+- [ ] T001 Start the MariaDB test container and create the test databases per `CLAUDE.md` ("Test Database Setup for Development"), using tox from the main checkout's venv. Confirm a green baseline for the fuel acceptance tests with `tox -e acceptance -- biweeklybudget/tests/acceptance/flaskapp/views/test_fuel.py`, output redirected to the scratchpad.
+
+---
+
+## Phase 2: Foundational (blocks all stories)
+
+**Purpose**: The setting exists with today's values as its default, reaches the page, and the form is built from it.
+
+- [ ] T002 Create `biweeklybudget/tests/unit/test_settings_fuel_levels.py` with the standard AGPL header (copy from an existing test module). Add `TestFuelLevelsDefault.test_default`, asserting `settings.FUEL_LEVELS == [('%d/10' % i, i * 10) for i in range(11)]`. The test settings module does not set `FUEL_LEVELS`, so this pins the default. Confirm it fails (no attribute) before T003.
+- [ ] T003 In `biweeklybudget/settings.py`, after `FUEL_ECO_ABBREVIATION`, add `FUEL_LEVELS = [('%d/10' % i, i * 10) for i in range(11)]` with a `#:` docstring. The docstring covers: an ordered list of `(label, percentage)` pairs offered as the Add Fuel Fill form's starting and ending fuel levels; the percentage (whole number 0–100) is what is stored; the form shows them in order and defaults to the lowest and highest percentage; the env-var syntax `label:percentage` separated by commas, split on the last colon, with no commas in labels; an example `E:0,1/4:25,1/2:50,3/4:75,F:100`; the validation rules from `contracts/fuel-levels-setting.md`; and a pointer to `:ref:`Currency Formatting and Localization <app_usage.l10n>``.
+- [ ] T004 [P] In `biweeklybudget/flaskapp/templates/fuel.html`, in the inline `<script>` that sets `fuel_budget_id` (~line 155), add `var FUEL_LEVELS = {{ settings.FUEL_LEVELS|tojson }};`.
+- [ ] T005 [P] In `biweeklybudget/flaskapp/static/js/fuel.js`:
+  - Add a JSDoc-commented `fuelLevelOptions(selectedValue)` that returns an Array of `{value: pct, label: <HTML-escaped label>, selected: pct == selectedValue}` built from the global `FUEL_LEVELS` in order. Reuse an existing HTML-escape helper from `static/js` if there is one; otherwise add a small local one escaping `& < > " '`.
+  - In `fuelModalDivForm()`, compute the min and max percentage in `FUEL_LEVELS`. Replace the two `addLabelToValueSelect(...)` calls for `fuel_frm_level_before`/`fuel_frm_level_after` with `addSelect(id, name, label, fuelLevelOptions(min|max))`, keeping the same ids, names and labels.
+
+**Checkpoint**: T002 passes. With no configuration the form should look exactly as before (verified in US2).
+
+---
+
+## Phase 3: User Story 1 — Log a fill using my own gauge's markings (Priority: P1) 🎯 MVP
+
+**Goal**: A configured list, from the settings module or the `FUEL_LEVELS` env var, drives both selects, in order, with the right defaults, and saving records the paired percentages.
+
+**Independent Test**: The US1 unit and acceptance tests below pass. Manually: `quickstart.md` step 2.
+
+### Tests for User Story 1
+
+- [ ] T006 [US1] In `test_settings_fuel_levels.py`, add `TestParseFuelLevels`:
+  - `E:0,1/4:25,1/2:50,3/4:75,F:100` → the five pairs in order.
+  - Whitespace around labels and percentages is stripped (` E : 0 , F:100 `).
+  - A label containing a colon splits on the last colon (`a:b:50` → `('a:b', 50)`).
+  - A non-digit percentage (`E:x`, `E:-5`, `E:1.5`) and an entry with no colon raise `ValueError`.
+
+  Also add `TestFuelLevelsEnvVar.test_env_var_is_used`, which runs `subprocess.run([sys.executable, '-c', 'import json; from biweeklybudget import settings; print(json.dumps(settings.FUEL_LEVELS))'], env={**os.environ, 'FUEL_LEVELS': 'E:0,1/2:50,F:100', 'DB_CONNSTRING': os.environ.get('DB_CONNSTRING', 'mysql+pymysql://u:p@127.0.0.1/x')}, capture_output=True, text=True)`. Assert return code 0 and the last stdout line parses to `[['E', 0], ['1/2', 50], ['F', 100]]`. Confirm these fail before T007.
+- [ ] T007 [US1] In `biweeklybudget/settings.py`, add module-level `parse_fuel_levels(value)` with a docstring, per research R3. Split on `,`; each entry is `rpartition(':')`, and an empty separator means `ValueError`. Strip both parts. The percentage must match `^\d+$`, else `ValueError` naming the offending entry. Return a list of `(label, int(pct))` tuples. After the `_DATE_VARS` env loop, add: `if 'FUEL_LEVELS' in os.environ: FUEL_LEVELS = parse_fuel_levels(os.environ['FUEL_LEVELS'])`, converting `ValueError` to `SystemExit('ERROR: FUEL_LEVELS setting is invalid: %s' % ex)`. T006 must pass.
+- [ ] T008 [US1] In `test_fuel.py`, append a new acceptance class `TestFuelLevelsConfigured` (same base class and `@pytest.mark.acceptance` / `usefixtures` pattern as the existing classes, checking how class-level DB refresh works so that fill IDs are predictable). Its tests:
+  - `test_1_custom_levels`: load `/fuel` and run `selenium.execute_script("FUEL_LEVELS = [['E', 0], ['1/4', 25], ['1/2', 50], ['3/4', 75], ['F', 100]];")`. Open **Add Fill**. Assert both selects' `[value, text]` options are exactly `[['0','E'],['25','1/4'],['50','1/2'],['75','3/4'],['100','F']]`, with `level_before` selected `0` and `level_after` selected `100`.
+  - `test_2_add_fill`: with the same override, fill the form like `test_12_fuel_add_no_trans` (add-transaction unchecked), choosing `1/4` → `F`. Save, and confirm the success message.
+  - `test_3_verify_db`: the new `FuelFill` has `level_before == 25` and `level_after == 100`.
+  - `test_4_numeric_and_markup_labels`: override with `[['8', 100], ['4', 50], ['<b>0</b> & E', 0]]`. Assert option order and values are `[['100','8'],['50','4'],['0','<b>0</b> & E']]`, meaning the text is literal and there is no `<b>` element in the select. Assert `level_before` selected `0` and `level_after` selected `100`.
+
+**Checkpoint**: US1 delivered: a configured list drives the form and is stored as percentages.
+
+---
+
+## Phase 4: User Story 2 — Nothing changes for an operator who configures nothing (Priority: P1)
+
+**Goal**: With no configuration, the form, recorded values and defaults are identical to before.
+
+**Independent Test**: The existing default-list acceptance assertions pass unchanged, plus the check below.
+
+- [ ] T009 [US2] In `test_fuel.py`, leave `LEVEL_OPTS` and the `test_11_fuel_populate_modal` / `test_12` / `test_14` level assertions exactly as they are, so they guard FR-003. In `test_11_fuel_populate_modal`, after loading `/fuel`, add `assert selenium.execute_script('return FUEL_LEVELS;') == [[l, int(v)] for v, l in LEVEL_OPTS]`. This proves the server renders the default setting into the page. Run the fuel acceptance tests; all existing and new ones pass.
+
+**Checkpoint**: US1 and US2 pass.
+
+---
+
+## Phase 5: User Story 3 — A mistake in the configuration is reported, not silently used (Priority: P2)
+
+**Goal**: Any invalid list, from either source, aborts startup with an error naming `FUEL_LEVELS`.
+
+**Independent Test**: The US3 unit tests below pass. Manually: `quickstart.md` step 3.
+
+### Tests for User Story 3
+
+- [ ] T010 [US3] In `test_settings_fuel_levels.py`, add `TestValidateFuelLevels`:
+  - Valid lists of tuples and of lists return a list of `(label, pct)` tuples with labels stripped.
+  - Each of these raises `ValueError`, parametrized: fewer than two levels (0 and 1 entries); an entry that isn't a 2-item list/tuple (`('E',)`, `('E', 0, 1)`, a bare string); an empty or whitespace label; a non-str label (`None`); percentage `0.5`, `'50'`, `True`; percentage `-1` or `101`; a duplicated label; a duplicated percentage; a non-list value (`None`, `'E:0,F:100'`).
+  - The boundaries 0 and 100 are accepted.
+
+  Add `TestFuelLevelsEnvVar.test_invalid_env_var_exits`, parametrized over `E:0,F:150`, `F:100`, `E:0,E:50,F:100`, `E:x,F:100` and using the T006 subprocess helper. Assert a non-zero return code and `'FUEL_LEVELS setting is invalid'` in stderr. Confirm these fail before T011.
+- [ ] T011 [US3] In `biweeklybudget/settings.py`, add module-level `validate_fuel_levels(levels)` with a docstring implementing the rules in `contracts/fuel-levels-setting.md` (research R4). It returns a new normalised list and raises `ValueError` with a specific reason. After the env-var step from T007, and before the `_REQUIRED_VARS` check, run `FUEL_LEVELS = validate_fuel_levels(FUEL_LEVELS)`, converting `ValueError` to the same `SystemExit` message. T010 and all earlier tests must pass.
+
+**Checkpoint**: All three stories pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T012 [P] In `docs/source/app_usage.rst`, in the Fuel Log settings list (~line 66), add a bullet for `:py:attr:`biweeklybudget.settings.FUEL_LEVELS``, which sets the fuel level choices on the Add Fuel Fill form. Adjust the following sentence, which says these settings only affect display of units, so it stays accurate.
+- [ ] T013 [P] In `docs/source/http_api.rst` (~line 730), change the `level_before`/`level_after` descriptions to say the value is a percentage of a full tank (0-100), normally one of the `FUEL_LEVELS` setting's percentages.
+- [ ] T014 [P] In `CHANGES.rst`, add one concise bullet at the top of `Unreleased`, led by the `Issue #208` link: the fuel level choices on the Add Fuel Fill form are now configurable via the new `FUEL_LEVELS` setting; the default is unchanged. Add a short sub-bullet with the env-var format example. Do not touch `biweeklybudget/version.py`.
+- [ ] T015 Run the Test Gate (Constitution II) to completion, redirecting output to scratchpad files:
+  - `tox -e py314`, which also covers pycodestyle and pyflakes.
+  - `tox -e acceptance`.
+  - `tox -e docs`.
+
+  Raise the timeouts and re-run if a suite times out, rather than narrowing it. `migrations`, `docker`, and `plaid` are not engaged and run in CI.
+- [ ] T016 Manually walk through `quickstart.md` steps 1–3 against `flask rundev`, or record why that wasn't possible.
+- [ ] T017 Record results in the spec artifacts: set `spec.md` Status to Complete, mark the tasks here done, and add a "Test Gate Results" section to `plan.md`. Commit with the prefix `Configurable Fuel Levels - M1.x`.
+- [ ] T018 Push the branch to `origin` and open the pull request, following `.github/PULL_REQUEST_TEMPLATE.md` and surfacing the spec's Assumptions (global list, percentages stored) for the maintainer. Then monitor CI and answer reviews until Claude's review says "No issues found" and Copilot's, if present, recommends approval.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (T001)** blocks everything that runs tests.
+- **Foundational**: T002 → T003. T004 and T005 are independent files and can be done alongside T003. All of T002–T005 block the stories.
+- **US1**: T006 → T007 (unit). T008 (acceptance) depends on T004/T005 only.
+- **US2**: T009 depends on T004/T005.
+- **US3**: T010 → T011. T011 edits the same import-time block as T007, so it follows it.
+- **Polish**: T012–T014 are different files and can run in parallel at any time after T003. T015 depends on T002–T014. T016 needs T011. T017 depends on T015/T016, and T018 on T017.
+
+### User Story Dependencies
+
+- US1, US2 and US3 all depend on Foundational only. US3's validation also runs on US1's env-var output, but its tests don't need US1's code.
+- T006, T010 and T002 share one test file, and T008 and T009 share `test_fuel.py`, so tasks within each file are done sequentially.
+
+### Parallel Opportunities
+
+- T004 ∥ T005 ∥ T003.
+- T012 ∥ T013 ∥ T014.
+- Within T015, run the `docs` suite concurrently with the DB suites. Run `py314` and `acceptance` sequentially, since both use the test database.
+
+---
+
+## Parallel Example: Foundational
+
+```bash
+Task: "Add FUEL_LEVELS default + docstring in biweeklybudget/settings.py"
+Task: "Expose FUEL_LEVELS global in biweeklybudget/flaskapp/templates/fuel.html"
+Task: "Build level selects from FUEL_LEVELS in biweeklybudget/flaskapp/static/js/fuel.js"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+T001–T008 is the MVP: a settings-module or env-var list drives the form. T009 locks in the
+unchanged default, T010–T011 add safety, and T012–T018 document, verify and deliver. At
+this size all of it ships together as milestone M1 in one pull request.
+
+---
+
+## Notes
+
+- Unit tests need the MariaDB container (see `CLAUDE.md`). Without it, `test_plaid.py` and `test_utils.py` fail to collect.
+- Never test import-time behaviour with `importlib.reload(settings)`. Other modules hold references to the module object, and a failed reload leaves it half-initialised. Use a subprocess.
+- Flaky `TestDragLimitations::test_11_unreconcile` (reconcile) is a known intermittent failure. Re-run it in isolation before blaming this change.


### PR DESCRIPTION
Closes #208.

## Summary

The Add Fuel Fill form's "Starting Fuel Level" and "Ending Fuel Level" choices were hard-coded to tenths (`0/10` … `10/10`). They now come from a new `FUEL_LEVELS` setting, so they can match gauges marked in quarters, eighths, `E`/`F`, or anything else.

- **`FUEL_LEVELS`** (`biweeklybudget/settings.py`): an ordered list of `(label, percentage)` pairs. The **default reproduces today's options exactly**, so nothing changes for anyone who doesn't set it.
  - Settings module: `FUEL_LEVELS = [('E', 0), ('1/4', 25), ('1/2', 50), ('3/4', 75), ('F', 100)]`
  - Environment variable: `FUEL_LEVELS="E:0,1/4:25,1/2:50,3/4:75,F:100"`
- **Validated at startup.** Fewer than two levels, an empty or duplicated label, a duplicated percentage, or a percentage that isn't an integer from 0 to 100 exits with `ERROR: FUEL_LEVELS setting is invalid: <reason>`, as the other settings already do.
- **Form**: both selects show the configured levels in order. The starting level defaults to the lowest percentage and the ending level to the highest. Labels are HTML-escaped, and the list reaches the page via `tojson`.
- **Storage is unchanged.** A fill still stores a percentage of a full tank, so there is no migration, and existing fills, the fuel log table, charts and the HTTP API are unaffected.
- `escapeHtml()` moved from `budgets_modal.js` to `custom.js` (loaded on every page) so `fuel.js` can reuse it. There is no behaviour change on the budgets page.

Spec Kit artifacts: `specs/20260912-073811-configurable-fuel-levels/` (spec, plan, research, contract, tasks).

## Decisions for the maintainer to confirm or overrule

These are recorded in the spec's Assumptions:

1. **One list for the whole application, not per vehicle.** It matches the other Fuel Log settings. Per-vehicle lists would need a schema and vehicle-modal change, and could be added later on top of this.
2. **Levels stay stored as percentages**, not labels, so fills logged under different lists stay comparable and no migration is needed.
3. **The fuel log table keeps showing percentages** (`25%`), not labels.
4. **`POST /forms/fuel` is unchanged.** It still accepts any integer level and doesn't restrict to the configured list.

## Testing

Run locally against MariaDB 10.4.7 (the CI image), Python 3.14.7:

| Suite | Result |
|-------|--------|
| `tox -e py314` (unit + pycodestyle + pyflakes) | 936 passed, 6 skipped, 0 failed |
| `tox -e acceptance` | 797 passed, 24 skipped, 0 failed (17m42s) |
| `tox -e docs` | Builds (exit 0), with no warnings from this change |

- **New unit tests** (`tests/unit/test_settings_fuel_levels.py`, 49 tests) cover:
  - the default list;
  - env-var parsing;
  - every validation rule;
  - import-time behaviour, run in a subprocess so the shared `settings` module is never reloaded. An invalid `FUEL_LEVELS` exits non-zero with the error, and a valid one is used.

  They failed before the implementation (`ImportError`) and pass after.
- **New acceptance tests** (`TestFuelLevelsConfigured`) replace the page's `FUEL_LEVELS` global with a custom list and check:
  - options, order and defaults;
  - saving a fill with `1/4` → `F`, which records `25`/`100`;
  - integer-like labels in non-numeric order;
  - a label containing `<b>…</b> &`, which is shown as literal text.
- **Default behaviour.** The existing default-list assertions (`LEVEL_OPTS`) are unchanged and pass. `test_11` now also checks that the page's `FUEL_LEVELS` global equals the default.
- **Manual check.** `flask run` with `FUEL_LEVELS='E:0,1/4:25,1/2 </script>:50,3/4:75,F:100'` renders `var FUEL_LEVELS = [["E", 0], ["1/4", 25], ["1/2 \u003c/script\u003e", 50], …]` (so `tojson` escapes the `<`), and an invalid value stops startup with `ERROR: FUEL_LEVELS setting is invalid: …`.
- **Known flake, unrelated.** `TestFuelLogView::test_04_search` failed once in a focused fuel run. It read the fuel log table before the DataTables search had applied. It then passed in three isolated re-runs with this change in place. That table isn't touched here.

## Pull Request Checklist

- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Code should conform to the following:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] Test coverage with pytest (with valid tests). The new `parse_fuel_levels()` and `validate_fuel_levels()` are fully covered.
      The four import-time lines that apply them (`settings.py` 402-403 and 405-406) run only in the subprocess import tests,
      which in-process coverage doesn't count. `settings.py` is 82% overall, and its other uncovered lines (the existing env-var loops) predate this change.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] An entry for this change has been added at the top of ``CHANGES.rst``, under the ``Unreleased`` heading. ``version.py`` is unchanged.
    - [x] The changelog entry is concise.
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** are meaningful and reference the feature/milestone.
    - [x] Git history is fully intact.

## Contributor License Agreement

By submitting this work for inclusion in biweeklybudget, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the biweeklybudget project (the Affero GPL v3,
  or any subsequent version of that license if adopted by biweeklybudget).
* My contribution may perpetually be included in and distributed with biweeklybudget; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of biweeklybudget's license.
* I have the legal power and rights to agree to these terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwDdUef5ZwuXUB5jyBbA3x
